### PR TITLE
feat: real-signal content sources (HN + GitHub Trending + Product Hunt)

### DIFF
--- a/.github/workflows/daily-edition.yml
+++ b/.github/workflows/daily-edition.yml
@@ -49,6 +49,9 @@ jobs:
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           AMAZON_AFFILIATE_TAG: ${{ secrets.AMAZON_AFFILIATE_TAG }}
+          # Signal sources (optional — pipeline falls back to pure AI if missing)
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRODUCT_HUNT_TOKEN: ${{ secrets.PRODUCT_HUNT_TOKEN }}
         run: node scripts/generate-daily-content.js
 
       - name: Validate JSON files

--- a/.github/workflows/smoke-signal-sources.yml
+++ b/.github/workflows/smoke-signal-sources.yml
@@ -1,0 +1,41 @@
+name: Smoke Test — Signal Sources
+
+on:
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Probe signal sources
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRODUCT_HUNT_TOKEN: ${{ secrets.PRODUCT_HUNT_TOKEN }}
+        run: |
+          node -e "
+          const { getSeedsForCategory, formatSeeds, fetchProductHunt } = require('./scripts/lib/signal-sources.js');
+          (async () => {
+            console.log('== Product Hunt (direct) ==');
+            const ph = await fetchProductHunt({ limit: 3 });
+            console.log('count:', ph.length);
+            if (ph.length) console.log(JSON.stringify(ph[0], null, 2));
+
+            for (const cat of ['hidden-gems', 'daily-tools', 'future-radar', 'products']) {
+              const s = await getSeedsForCategory(cat);
+              console.log('\n== ' + cat + ' ==', s.length, 'seeds from', [...new Set(s.map(x => x.source))].join(', '));
+              if (s.length) console.log(formatSeeds(s.slice(0, 2)));
+            }
+
+            // Fail if PH returned nothing — token is expected to be set
+            if (ph.length === 0) {
+              console.error('\n❌ PRODUCT_HUNT_TOKEN returned no items — token may be invalid or expired.');
+              process.exit(1);
+            }
+            console.log('\n✅ All sources working.');
+          })();
+          "

--- a/scripts/generate-daily-content.js
+++ b/scripts/generate-daily-content.js
@@ -3,6 +3,7 @@ const fs = require("fs");
 const path = require("path");
 const { writeJsonSafe } = require("./lib/write-safe");
 const { createLogger } = require("./lib/logger");
+const { getSeedsForCategory, formatSeeds } = require("./lib/signal-sources");
 
 const log = createLogger({ script: 'generate-daily-content' });
 
@@ -69,12 +70,27 @@ async function callWithRetry(fn, maxRetries = 3) {
   }
 }
 
-async function generateItems(category, existingItems, count) {
+async function generateItems(category, existingItems, count, seeds = []) {
   const existingSlugs = getExistingSlugs(existingItems);
   const existingTitles = existingItems
     .slice(-30)
     .map((i) => i.title || i.name || i.toolName || i.techName)
     .join(", ");
+
+  // De-dupe seeds against items we already have (by URL host+path or name)
+  const existingUrls = new Set(
+    existingItems
+      .map((i) => (i.websiteLink || i.sourceLink || "").replace(/\/$/, "").toLowerCase())
+      .filter(Boolean)
+  );
+  const existingNamesLower = new Set(
+    existingItems.map((i) => (i.title || i.name || i.toolName || i.techName || "").toLowerCase())
+  );
+  const filteredSeeds = seeds.filter((s) => {
+    const u = (s.url || "").replace(/\/$/, "").toLowerCase();
+    const n = (s.title || "").toLowerCase();
+    return !existingUrls.has(u) && !existingNamesLower.has(n);
+  });
 
   const schemas = {
     discoveries: `{
@@ -150,18 +166,30 @@ async function generateItems(category, existingItems, count) {
       "Find 3 real, useful everyday tools or apps with working URLs. Focus on well-regarded tools that help with productivity, creativity, or daily life. Write descriptions detailed enough to explain the tool's value to someone who has never heard of it. CRITICAL: The websiteLink field MUST be a real, working URL to the tool's actual website (e.g., 'https://notion.so'). Never use placeholder or example URLs.",
   };
 
-  const prompt = `${categoryPrompts[category]}
+  const seedBlock = filteredSeeds.length
+    ? `
+REAL TRENDING ITEMS — pick the ${count} most interesting and fitting for Surfaced from this list.
+These are currently trending on Hacker News / GitHub / Product Hunt. You MUST use the EXACT name
+and EXACT URL from the chosen seed (do not invent, rename, or substitute). Only the copy
+(description/why fields/imageIdea/category/slug) is yours to write:
 
+${formatSeeds(filteredSeeds)}
+
+`
+    : "";
+
+  const prompt = `${categoryPrompts[category]}
+${seedBlock}
 EXISTING items to AVOID duplicating (these already exist): ${existingTitles}
 
 Return EXACTLY ${count} items as a JSON array. Each item must match this exact schema:
 ${schemas[category]}
 
 Rules:
-- All URLs must be real, publicly accessible websites
+- All URLs must be real, publicly accessible websites${filteredSeeds.length ? " — use the EXACT URL from the seed you picked" : ""}
 - imageIdea must be a concrete visual noun (e.g. "espresso machine coffee barista"), NEVER abstract concepts
 - slug must be kebab-case, unique, derived from the title/name
-- Descriptions should be engaging and informative
+- Descriptions should be engaging and informative — add depth, context, and specifics beyond the raw seed blurb
 - Today's date for reference: ${today}
 
 Return ONLY the JSON array, no markdown fencing, no explanation.`;
@@ -239,7 +267,11 @@ async function main() {
     for (const [category, filename] of Object.entries(FILES)) {
       console.log(`[${category}] Generating 5 new items...`);
       const existing = readJSON(filename);
-      const newItems = await generateItems(category, existing, 5);
+      const seeds = await getSeedsForCategory(category);
+      if (seeds.length) {
+        console.log(`[${category}] Seeded with ${seeds.length} real trending items (${[...new Set(seeds.map((s) => s.source))].join(", ")})`);
+      }
+      const newItems = await generateItems(category, existing, 5, seeds);
       console.log(
         `[${category}] Generated: ${newItems.map((i) => i.slug).join(", ")}`
       );

--- a/scripts/lib/signal-sources.js
+++ b/scripts/lib/signal-sources.js
@@ -39,6 +39,41 @@ async function fetchJson(url, opts = {}) {
 }
 
 /**
+ * Strip tracking parameters (utm_*, ref, fbclid, etc.) from a URL.
+ * Leaves legitimate query params intact.
+ */
+function stripTracking(url) {
+  try {
+    const u = new URL(url);
+    const junk = [];
+    for (const key of u.searchParams.keys()) {
+      if (
+        key.startsWith("utm_") ||
+        key === "ref" ||
+        key === "ref_src" ||
+        key === "ref_url" ||
+        key === "referrer" ||
+        key === "fbclid" ||
+        key === "gclid" ||
+        key === "mc_cid" ||
+        key === "mc_eid"
+      ) {
+        junk.push(key);
+      }
+    }
+    junk.forEach((k) => u.searchParams.delete(k));
+    return u.toString().replace(/\?$/, "");
+  } catch {
+    return url;
+  }
+}
+
+// Note: PH's /r/<id> redirect URLs return 403 to non-browser clients (Cloudflare bot
+// protection), so we can't resolve them server-side. Real users clicking the link
+// in a browser get redirected to the product's real site — we just strip tracking
+// params so the URL looks clean in Surfaced's UI.
+
+/**
  * Hacker News front page — items with external URLs.
  * Great for hidden-gems (Show HN, interesting sites) and future-radar (research).
  */
@@ -154,7 +189,7 @@ async function fetchProductHunt({ limit = 8 } = {}) {
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const data = await res.json();
     const edges = data?.data?.posts?.edges || [];
-    return edges.slice(0, limit).map(({ node }) => ({
+    const items = edges.slice(0, limit).map(({ node }) => ({
       title: node.name,
       tagline: node.tagline,
       description: node.description,
@@ -163,6 +198,12 @@ async function fetchProductHunt({ limit = 8 } = {}) {
       topics: (node.topics?.edges || []).map((e) => e.node.name),
       source: "producthunt",
     }));
+    // PH returns UTM-laden /r/<id> redirect URLs. Strip tracking so item pages
+    // show clean URLs; the redirect still works fine for real users in a browser.
+    for (const item of items) {
+      item.url = stripTracking(item.url);
+    }
+    return items;
   } catch (err) {
     console.warn(`  ⚠ Product Hunt fetch failed: ${err.message}`);
     return [];

--- a/scripts/lib/signal-sources.js
+++ b/scripts/lib/signal-sources.js
@@ -1,0 +1,226 @@
+/**
+ * Real-world signal sources for daily content generation.
+ *
+ * Each fetcher returns a small array of seed items — real, currently-trending
+ * things — that Gemini then rewrites into Surfaced's schema. This turns the
+ * pipeline from "AI-guessed content" into "curated signal, AI-polished copy."
+ *
+ * All fetchers fail soft: if the API is down or creds are missing, they return []
+ * and the caller falls back to pure AI generation.
+ *
+ * Sources:
+ *   - Hacker News  (no auth)   → hidden-gems, future-radar
+ *   - GitHub search (optional GITHUB_TOKEN for higher rate limit) → daily-tools
+ *   - Product Hunt (requires PRODUCT_HUNT_TOKEN) → products, daily-tools
+ */
+
+const HN_TOP = "https://hacker-news.firebaseio.com/v0/topstories.json";
+const HN_ITEM = (id) => `https://hacker-news.firebaseio.com/v0/item/${id}.json`;
+const HN_ALGOLIA = "https://hn.algolia.com/api/v1/search";
+const GH_SEARCH = "https://api.github.com/search/repositories";
+const PH_GQL = "https://api.producthunt.com/v2/api/graphql";
+
+const UA = "Surfaced-SignalFetcher/1.0 (https://surfaced-x.pages.dev)";
+
+async function fetchJson(url, opts = {}) {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), opts.timeout || 10000);
+  try {
+    const res = await fetch(url, {
+      ...opts,
+      signal: ctrl.signal,
+      headers: { "User-Agent": UA, Accept: "application/json", ...(opts.headers || {}) },
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return await res.json();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Hacker News front page — items with external URLs.
+ * Great for hidden-gems (Show HN, interesting sites) and future-radar (research).
+ */
+async function fetchHackerNews({ limit = 10, minScore = 100 } = {}) {
+  try {
+    const ids = await fetchJson(HN_TOP);
+    const top = ids.slice(0, 60);
+    const stories = await Promise.all(top.map((id) => fetchJson(HN_ITEM(id)).catch(() => null)));
+    return stories
+      .filter((s) => s && s.url && s.title && (s.score || 0) >= minScore)
+      .filter((s) => !/^https?:\/\/(news\.ycombinator|twitter|x)\.com/.test(s.url))
+      .slice(0, limit)
+      .map((s) => ({
+        title: s.title,
+        url: s.url,
+        score: s.score,
+        source: "hackernews",
+      }));
+  } catch (err) {
+    console.warn(`  ⚠ HN fetch failed: ${err.message}`);
+    return [];
+  }
+}
+
+/**
+ * Show HN posts — specifically projects/tools authors are launching.
+ * Highest-quality seed for hidden-gems.
+ */
+async function fetchShowHN({ limit = 8 } = {}) {
+  try {
+    const since = Math.floor(Date.now() / 1000) - 7 * 24 * 3600;
+    const url = `${HN_ALGOLIA}?tags=show_hn&numericFilters=created_at_i>${since},points>20&hitsPerPage=${limit * 3}`;
+    const data = await fetchJson(url);
+    return (data.hits || [])
+      .filter((h) => h.url && h.title)
+      .slice(0, limit)
+      .map((h) => ({
+        title: h.title.replace(/^Show HN:\s*/i, ""),
+        url: h.url,
+        score: h.points,
+        source: "show-hn",
+      }));
+  } catch (err) {
+    console.warn(`  ⚠ Show HN fetch failed: ${err.message}`);
+    return [];
+  }
+}
+
+/**
+ * GitHub trending (proxy via search API: recent repos, sorted by stars).
+ * Token optional — unauthenticated = 60 req/hr (plenty for daily use).
+ */
+async function fetchGitHubTrending({ limit = 8, minStars = 50, daysBack = 14 } = {}) {
+  try {
+    const since = new Date(Date.now() - daysBack * 24 * 3600 * 1000).toISOString().slice(0, 10);
+    const q = `created:>${since} stars:>${minStars}`;
+    const url = `${GH_SEARCH}?q=${encodeURIComponent(q)}&sort=stars&order=desc&per_page=${limit * 2}`;
+    const headers = { Accept: "application/vnd.github+json" };
+    if (process.env.GITHUB_TOKEN) headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+    const data = await fetchJson(url, { headers });
+    return (data.items || [])
+      .filter((r) => r.description && !r.fork && !r.archived)
+      .slice(0, limit)
+      .map((r) => ({
+        title: r.name,
+        fullName: r.full_name,
+        url: r.html_url,
+        homepage: r.homepage || null,
+        description: r.description,
+        score: r.stargazers_count,
+        language: r.language,
+        source: "github",
+      }));
+  } catch (err) {
+    console.warn(`  ⚠ GitHub trending fetch failed: ${err.message}`);
+    return [];
+  }
+}
+
+/**
+ * Product Hunt top posts from the last 24h. Requires developer token.
+ * Fails soft (returns []) when PRODUCT_HUNT_TOKEN is absent.
+ */
+async function fetchProductHunt({ limit = 8 } = {}) {
+  const token = process.env.PRODUCT_HUNT_TOKEN;
+  if (!token) return [];
+  try {
+    const query = `
+      query {
+        posts(order: VOTES, first: ${limit * 2}) {
+          edges {
+            node {
+              name
+              tagline
+              description
+              url
+              website
+              votesCount
+              topics(first: 3) { edges { node { name } } }
+            }
+          }
+        }
+      }`;
+    const res = await fetch(PH_GQL, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "User-Agent": UA,
+      },
+      body: JSON.stringify({ query }),
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    const edges = data?.data?.posts?.edges || [];
+    return edges.slice(0, limit).map(({ node }) => ({
+      title: node.name,
+      tagline: node.tagline,
+      description: node.description,
+      url: node.website || node.url,
+      score: node.votesCount,
+      topics: (node.topics?.edges || []).map((e) => e.node.name),
+      source: "producthunt",
+    }));
+  } catch (err) {
+    console.warn(`  ⚠ Product Hunt fetch failed: ${err.message}`);
+    return [];
+  }
+}
+
+/**
+ * Format seed items as a compact block for the Gemini prompt.
+ * Gemini is told to select N and rewrite them in Surfaced's schema,
+ * keeping the real URL, name, and factual core intact.
+ */
+function formatSeeds(seeds) {
+  if (!seeds.length) return "";
+  return seeds
+    .map((s, i) => {
+      const parts = [`${i + 1}. ${s.title}`];
+      if (s.tagline) parts.push(`   Tagline: ${s.tagline}`);
+      if (s.description && s.description !== s.tagline) parts.push(`   Desc: ${s.description.slice(0, 200)}`);
+      if (s.language) parts.push(`   Language: ${s.language}`);
+      if (s.topics?.length) parts.push(`   Topics: ${s.topics.join(", ")}`);
+      parts.push(`   URL: ${s.url}`);
+      if (s.score) parts.push(`   Signal: ${s.score} ${s.source === "github" ? "stars" : "points/votes"} on ${s.source}`);
+      return parts.join("\n");
+    })
+    .join("\n\n");
+}
+
+/**
+ * Get seeds appropriate for a given content category.
+ * Fetches multiple sources in parallel and combines.
+ */
+async function getSeedsForCategory(category) {
+  switch (category) {
+    case "hidden-gems": {
+      const [show, hn] = await Promise.all([fetchShowHN({ limit: 6 }), fetchHackerNews({ limit: 4, minScore: 200 })]);
+      return [...show, ...hn].slice(0, 8);
+    }
+    case "daily-tools": {
+      const [gh, ph] = await Promise.all([fetchGitHubTrending({ limit: 6 }), fetchProductHunt({ limit: 4 })]);
+      return [...gh, ...ph].slice(0, 8);
+    }
+    case "future-radar": {
+      return fetchHackerNews({ limit: 6, minScore: 150 });
+    }
+    case "products": {
+      return fetchProductHunt({ limit: 6 });
+    }
+    case "discoveries":
+    default:
+      return [];
+  }
+}
+
+module.exports = {
+  fetchHackerNews,
+  fetchShowHN,
+  fetchGitHubTrending,
+  fetchProductHunt,
+  getSeedsForCategory,
+  formatSeeds,
+};


### PR DESCRIPTION
## Summary
- Wires Hacker News, GitHub Trending, and Product Hunt as seed sources for the daily content pipeline
- Gemini rewrites copy around real trending items instead of hallucinating them — shifts Surfaced from "AI blog" to "curated with taste"
- Fails soft: missing token or API error → that category falls back to pure AI (zero breakage)
- Strips UTM/tracking params from PH URLs so item pages show clean links

## Category mapping
- `hidden-gems` → Show HN + HN front page
- `daily-tools` → GitHub Trending + Product Hunt
- `future-radar` → HN front page
- `products` → Product Hunt
- `discoveries` → pure AI (no good free API source for facts)

## Test plan
- [x] HN / Show HN / GitHub sources verified locally (3+ items each)
- [x] Product Hunt token verified live (5 items, clean URLs)
- [x] Graceful fallback confirmed (missing token → 0 seeds, not an error)
- [x] Syntax check passes on generate-daily-content.js
- [ ] Next scheduled 7am ET run will exercise the full pipeline end-to-end
- [ ] Smoke workflow (`.github/workflows/smoke-signal-sources.yml`) available for on-demand diagnostics once on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)