### PR TITLE
Harden AdSense readiness gates

### DIFF
--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: AdSense content audit
+        run: npm run audit:adsense
+
       - name: Build site
         id: build
         run: |
@@ -217,7 +220,9 @@ jobs:
             "out/future-radar.html"
             "out/tools.html"
             "out/affiliate-disclosure.html"
+            "out/contact.html"
             "out/privacy.html"
+            "out/premium.html"
             "out/terms.html"
             "out/newsletter.html"
             "out/saved.html"

--- a/.github/workflows/daily-edition.yml
+++ b/.github/workflows/daily-edition.yml
@@ -68,6 +68,9 @@ jobs:
       - name: Validate JSON files
         run: node scripts/validate-data.js
 
+      - name: AdSense content quality gate
+        run: node scripts/audit-adsense-content.mjs --strict
+
       - name: Validate outbound URLs (recent items)
         run: node scripts/validate-urls.js --recent
         continue-on-error: true

--- a/docs/adsense-compliance-readiness.md
+++ b/docs/adsense-compliance-readiness.md
@@ -1,6 +1,6 @@
 # AdSense Compliance Readiness
 
-Last updated: 2026-05-03
+Last updated: 2026-05-04
 
 ## Current publisher setup
 
@@ -12,9 +12,9 @@ Last updated: 2026-05-03
 - AdSense client ID in code: `ca-pub-8054019783472830`
 - `ads.txt`: `google.com, pub-8054019783472830, DIRECT, f08c47fec0942fa0`
 
-The site owner does not want a personal legal name shown publicly. Until an LLC
-or DBA is formed, public-facing policy pages should use Surfaced as the site
-name and `surfaced-x@protonmail.com` as the contact address.
+Do not publish a personal legal name on site surfaces. Until an LLC or DBA is
+formed, public-facing policy pages should use Surfaced or the Surfaced Team and
+`surfaced-x@protonmail.com` as the contact address.
 
 ## Ad serving guardrails
 
@@ -22,15 +22,18 @@ AdSense Auto Ads are loaded by `src/components/AdSenseLoader.tsx`, not directly
 from the root layout. The loader intentionally skips:
 
 - `/item/*`
+- `/about`
 - `/privacy`
 - `/terms`
 - `/affiliate-disclosure`
 - `/contact`
+- `/newsletter`
+- `/premium`
 - `/saved`
 
-This keeps Google-served ads away from item detail pages until the strict
-content audit clears all thin pages, duplicate body copy, and weak source URLs.
-It also avoids ads on legal/contact/saved utility pages.
+This keeps Google-served ads away from item detail pages and utility/legal pages
+that are weaker monetization surfaces. The loader also removes the Auto Ads
+script if a client-side navigation lands on an excluded path.
 
 ## Google Privacy & messaging
 
@@ -43,16 +46,21 @@ Choices / Privacy & messaging endpoints used by those messages.
 Run:
 
 ```bash
-node scripts/validate-data.js
-node scripts/audit-adsense-content.mjs --strict
+npm run audit:adsense
+npm run audit:adsense:live
 npm run build
 ```
 
 The strict AdSense audit must report:
 
 - `thin item bodies (<100 words): 0`
+- `review item bodies (<150 words): 0`
 - `exact duplicate body groups: 0`
 - `low-quality source URLs: 0`
+
+The daily workflow and build-validation workflow both run the strict content
+audit, so newly generated AI pages cannot deploy if they fall below the review
+threshold or reintroduce duplicate/weak-source signals.
 
 The workflow `.github/workflows/adsense-remediation.yml` can be run manually in
 `remediate` mode to enrich thin pages and replace weak sources with the

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "build": "next build",
     "postbuild": "node scripts/strip-rsc-payloads.mjs && node scripts/validate-seo.mjs --warn",
     "validate:seo": "node scripts/validate-seo.mjs",
+    "audit:adsense": "node scripts/validate-data.js && node scripts/audit-adsense-content.mjs --strict",
+    "audit:adsense:live": "node scripts/audit-live-adsense.mjs",
     "seo:ping": "node scripts/ping-search-engines.mjs",
     "start": "next start",
     "lint": "eslint",

--- a/scripts/audit-adsense-content.mjs
+++ b/scripts/audit-adsense-content.mjs
@@ -155,8 +155,17 @@ if (lowQuality.length > 0) {
   }
 }
 
-if (STRICT && (thin.length > 0 || duplicateGroups.length > 0 || lowQuality.length > 0)) {
+if (STRICT && (needsReview.length > 0 || duplicateGroups.length > 0 || lowQuality.length > 0)) {
   console.log("\nStrict audit failed.");
+  if (needsReview.length > 0) {
+    console.log(`  ${needsReview.length} item page(s) are below the ${REVIEW_WORDS}-word review threshold.`);
+  }
+  if (duplicateGroups.length > 0) {
+    console.log(`  ${duplicateGroups.length} exact duplicate body group(s) found.`);
+  }
+  if (lowQuality.length > 0) {
+    console.log(`  ${lowQuality.length} low-quality source URL(s) found.`);
+  }
   process.exit(1);
 }
 

--- a/scripts/audit-live-adsense.mjs
+++ b/scripts/audit-live-adsense.mjs
@@ -112,16 +112,13 @@ function headerIncludes(res, headerName, requiredTokens, failures) {
   }
 }
 
-function decodeHtmlEntities(text) {
-  return text
-    .replace(/&amp;/g, "&")
-    .replace(/&#x27;/g, "'")
-    .replace(/&quot;/g, '"')
-    .replace(/&nbsp;/g, " ");
-}
-
 function escapeRegExp(text) {
   return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function containsRequiredText(html, snippet) {
+  const escapedSnippet = snippet.replace(/&/g, "&amp;");
+  return html.includes(snippet) || html.includes(escapedSnippet);
 }
 
 async function main() {
@@ -174,9 +171,8 @@ async function main() {
     const { res, text } = await fetchText(page.path, failures);
     if (!res?.ok) continue;
     headerIncludes(res, "content-security-policy", REQUIRED_CSP_TOKENS, failures);
-    const readableText = decodeHtmlEntities(text);
     for (const snippet of page.requiredText) {
-      if (readableText.includes(snippet)) pass(`${page.label} contains ${snippet}`);
+      if (containsRequiredText(text, snippet)) pass(`${page.label} contains ${snippet}`);
       else fail(failures, `${page.label} missing ${snippet}`);
     }
   }

--- a/scripts/audit-live-adsense.mjs
+++ b/scripts/audit-live-adsense.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+/**
+ * Live AdSense readiness smoke audit.
+ *
+ * This intentionally checks only public, deterministic surfaces. Dashboard-only
+ * state, such as AdSense review status or whether Privacy & messaging messages
+ * are published, still has to be confirmed in AdSense.
+ *
+ * Usage:
+ *   node scripts/audit-live-adsense.mjs
+ *   node scripts/audit-live-adsense.mjs --base-url=https://example.com
+ */
+
+const DEFAULT_BASE_URL = "https://surfaced-x.pages.dev";
+const PUBLISHER_ID = "pub-8054019783472830";
+const ADS_TXT_LINE = `google.com, ${PUBLISHER_ID}, DIRECT, f08c47fec0942fa0`;
+const CONTACT_EMAIL = "surfaced-x@protonmail.com";
+
+const args = new Map(
+  process.argv
+    .slice(2)
+    .filter((arg) => arg.startsWith("--") && arg.includes("="))
+    .map((arg) => {
+      const [key, ...value] = arg.slice(2).split("=");
+      return [key, value.join("=")];
+    })
+);
+
+const BASE_URL = (args.get("base-url") || DEFAULT_BASE_URL).replace(/\/$/, "");
+
+const REQUIRED_CSP_TOKENS = [
+  "pagead2.googlesyndication.com",
+  "*.googlesyndication.com",
+  "fundingchoicesmessages.google.com",
+  "*.fundingchoicesmessages.google.com",
+  "googleads.g.doubleclick.net",
+];
+
+const PAGE_CHECKS = [
+  {
+    path: "/privacy",
+    label: "privacy policy",
+    requiredText: [
+      "Google AdSense",
+      "Third-party vendors, including Google",
+      "Google Ad Settings",
+      "aboutads.info",
+      "Privacy & Messaging",
+      "New York, United States",
+      CONTACT_EMAIL,
+    ],
+  },
+  {
+    path: "/terms",
+    label: "terms",
+    requiredText: ["State of New York", "United States", CONTACT_EMAIL],
+  },
+  {
+    path: "/affiliate-disclosure",
+    label: "affiliate disclosure",
+    requiredText: [
+      "affiliate links",
+      "Amazon Services LLC Associates Program",
+      "cover operating costs",
+      CONTACT_EMAIL,
+    ],
+  },
+  {
+    path: "/contact",
+    label: "contact",
+    requiredText: ["Surfaced", CONTACT_EMAIL],
+  },
+];
+
+function pass(message) {
+  console.log(`  OK  ${message}`);
+}
+
+function fail(failures, message) {
+  failures.push(message);
+  console.log(`  ERR ${message}`);
+}
+
+async function fetchText(pathname, failures, { expectedStatus = 200 } = {}) {
+  const url = `${BASE_URL}${pathname}`;
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), 15000);
+  try {
+    const res = await fetch(url, {
+      signal: ctrl.signal,
+      headers: { "User-Agent": "Surfaced-AdSense-Audit/1.0" },
+    });
+    const text = await res.text();
+    if (res.status !== expectedStatus) {
+      fail(failures, `${pathname} returned HTTP ${res.status}, expected ${expectedStatus}`);
+    }
+    return { res, text };
+  } catch (err) {
+    fail(failures, `${pathname} fetch failed: ${err.message}`);
+    return { res: null, text: "" };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function headerIncludes(res, headerName, requiredTokens, failures) {
+  const value = res?.headers.get(headerName) || "";
+  for (const token of requiredTokens) {
+    if (!value.includes(token)) {
+      fail(failures, `${headerName} missing ${token}`);
+    }
+  }
+}
+
+function decodeHtmlEntities(text) {
+  return text
+    .replace(/&amp;/g, "&")
+    .replace(/&#x27;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&nbsp;/g, " ");
+}
+
+function escapeRegExp(text) {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+async function main() {
+  const failures = [];
+  console.log(`\nAdSense live audit: ${BASE_URL}\n`);
+
+  const ads = await fetchText("/ads.txt", failures);
+  if (ads.res?.ok) {
+    const body = ads.text.trim();
+    if (body === ADS_TXT_LINE) pass("ads.txt has the exact Google seller line");
+    else fail(failures, `ads.txt body mismatch: ${JSON.stringify(body)}`);
+
+    const type = ads.res.headers.get("content-type") || "";
+    if (type.includes("text/plain")) pass("ads.txt is served as text/plain");
+    else fail(failures, `ads.txt content-type is ${type || "missing"}`);
+  }
+
+  const robots = await fetchText("/robots.txt", failures);
+  if (robots.res?.ok) {
+    const sitemapPattern = new RegExp(`Sitemap:\\s*${escapeRegExp(BASE_URL)}/sitemap\\.xml`, "i");
+    if (sitemapPattern.test(robots.text)) {
+      pass("robots.txt advertises the sitemap");
+    } else {
+      fail(failures, "robots.txt does not advertise the expected sitemap");
+    }
+    if (/Disallow:\s*\/ads\.txt/i.test(robots.text) || /Disallow:\s*\/\s*$/im.test(robots.text)) {
+      fail(failures, "robots.txt may block ads.txt or the whole site");
+    } else {
+      pass("robots.txt does not block ads.txt or site crawling");
+    }
+  }
+
+  const sitemap = await fetchText("/sitemap.xml", failures);
+  if (sitemap.res?.ok) {
+    const locCount = (sitemap.text.match(/<loc>/g) || []).length;
+    if (locCount >= 2500) pass(`sitemap exposes ${locCount} URLs`);
+    else fail(failures, `sitemap only exposes ${locCount} URLs`);
+    for (const path of ["/privacy", "/terms", "/affiliate-disclosure", "/contact"]) {
+      if (sitemap.text.includes(`${BASE_URL}${path}`)) pass(`sitemap includes ${path}`);
+      else fail(failures, `sitemap missing ${path}`);
+    }
+    if (sitemap.text.includes(`${BASE_URL}/saved`)) {
+      fail(failures, "sitemap includes noindex utility page /saved");
+    } else {
+      pass("sitemap excludes noindex utility page /saved");
+    }
+  }
+
+  for (const page of PAGE_CHECKS) {
+    const { res, text } = await fetchText(page.path, failures);
+    if (!res?.ok) continue;
+    headerIncludes(res, "content-security-policy", REQUIRED_CSP_TOKENS, failures);
+    const readableText = decodeHtmlEntities(text);
+    for (const snippet of page.requiredText) {
+      if (readableText.includes(snippet)) pass(`${page.label} contains ${snippet}`);
+      else fail(failures, `${page.label} missing ${snippet}`);
+    }
+  }
+
+  if (failures.length > 0) {
+    console.log(`\nLive audit failed: ${failures.length} issue(s)\n`);
+    for (const failure of failures) console.log(`- ${failure}`);
+    process.exit(1);
+  }
+
+  console.log("\nLive audit passed.\n");
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/src/app/saved/layout.tsx
+++ b/src/app/saved/layout.tsx
@@ -1,11 +1,13 @@
 import type { Metadata } from "next";
+import { buildMetadata } from "@/lib/seo";
 
-export const metadata: Metadata = {
+export const metadata: Metadata = buildMetadata({
   title: "Saved Items",
   description:
     "Your bookmarked discoveries, products, and finds — all in one place.",
-  robots: { index: false },
-};
+  path: "/saved",
+  noindex: true,
+});
 
 export default function SavedLayout({
   children,

--- a/src/components/AdSenseLoader.tsx
+++ b/src/components/AdSenseLoader.tsx
@@ -8,10 +8,13 @@ const ADSENSE_SCRIPT_ID = "google-adsense-auto-ads";
 
 const NO_AD_PREFIXES = [
   "/item/",
+  "/about",
   "/privacy",
   "/terms",
   "/affiliate-disclosure",
   "/contact",
+  "/newsletter",
+  "/premium",
   "/saved",
 ];
 
@@ -27,7 +30,17 @@ export function AdSenseLoader() {
   const pathname = usePathname();
 
   useEffect(() => {
-    if (!canShowAds(pathname)) return;
+    if (!canShowAds(pathname)) {
+      document.getElementById(ADSENSE_SCRIPT_ID)?.remove();
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        delete (window as any).adsbygoogle;
+      } catch {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (window as any).adsbygoogle = [];
+      }
+      return;
+    }
     if (document.getElementById(ADSENSE_SCRIPT_ID)) return;
 
     const script = document.createElement("script");


### PR DESCRIPTION
## Summary
- Adds stricter AdSense content gates so item pages under 150 body words fail CI instead of only showing as warnings.
- Runs the AdSense content audit in build validation and the daily content workflow to prevent new AI-generated thin pages from deploying.
- Adds a live AdSense smoke audit for ads.txt, robots.txt, sitemap, CSP, privacy, terms, affiliate disclosure, and contact surfaces.
- Keeps Auto Ads off weaker review surfaces, including item, legal, contact, saved, about, newsletter, and premium routes.
- Gives `/saved` explicit noindex/canonical metadata through the shared metadata helper.

## Verification
- `npm run audit:adsense`
- `npm run audit:adsense:live`
- `npm run build`
- `npm run validate:seo`

Note: `npm run lint` still fails on pre-existing repository-wide lint debt unrelated to this patch, mostly CommonJS automation scripts and existing React hook warnings.
