### PR TITLE
Enable ads on compliant item pages

### DIFF
--- a/docs/adsense-compliance-readiness.md
+++ b/docs/adsense-compliance-readiness.md
@@ -19,9 +19,10 @@ formed, public-facing policy pages should use Surfaced or the Surfaced Team and
 ## Ad serving guardrails
 
 AdSense Auto Ads are loaded by `src/components/AdSenseLoader.tsx`, not directly
-from the root layout. The loader intentionally skips:
+from the root layout. Item detail pages are eligible for Auto Ads because the
+strict content audit now requires every active and archived item URL to clear the
+review threshold. The loader intentionally skips:
 
-- `/item/*`
 - `/about`
 - `/privacy`
 - `/terms`
@@ -31,9 +32,10 @@ from the root layout. The loader intentionally skips:
 - `/premium`
 - `/saved`
 
-This keeps Google-served ads away from item detail pages and utility/legal pages
-that are weaker monetization surfaces. The loader also removes the Auto Ads
-script if a client-side navigation lands on an excluded path.
+This keeps Google-served ads away from utility, legal, account-like, and
+site-information pages that are weaker monetization surfaces. The loader also
+removes the Auto Ads script if a client-side navigation lands on an excluded
+path.
 
 ## Google Privacy & messaging
 

--- a/src/components/AdSenseLoader.tsx
+++ b/src/components/AdSenseLoader.tsx
@@ -7,7 +7,6 @@ const ADSENSE_CLIENT = "ca-pub-8054019783472830";
 const ADSENSE_SCRIPT_ID = "google-adsense-auto-ads";
 
 const NO_AD_PREFIXES = [
-  "/item/",
   "/about",
   "/privacy",
   "/terms",


### PR DESCRIPTION
## Summary
- allow AdSense Auto Ads on item detail pages now that strict content gates require every item URL to clear the 150-word review threshold
- keep utility, legal, newsletter, premium, saved, and site-info pages excluded from Auto Ads
- update the AdSense readiness notes to document the monetization guardrail

## Verification
- npm run audit:adsense
- npm run audit:adsense:live
- npm run build
- local static browser smoke: item page injects AdSense client script; excluded pages do not