### PR TITLE
chore: extend backup-restore + diagnostic surfacing in automation scripts

### DIFF
--- a/scripts/automated-content-brain.mjs
+++ b/scripts/automated-content-brain.mjs
@@ -282,7 +282,16 @@ function runCurrentEventDiscovery() {
       apiStatus: payload.apiStatus || {},
     };
   } catch (error) {
-    return { ok: false, error: `daily discovery JSON parse failed: ${error.message}`, candidates: [] };
+    // Spawned script exited 0 but stdout is not valid JSON. Surface stderr
+    // and a stdout snippet so the trending-live decisionLog is self-diagnosing.
+    const stderrTail = (result.stderr || "").trim().slice(-300);
+    const stdoutHead = (result.stdout || "").trim().slice(0, 200);
+    const detail = [
+      `daily discovery JSON parse failed: ${error.message}`,
+      stderrTail && `stderr: ${stderrTail}`,
+      stdoutHead && `stdout[0..200]: ${stdoutHead}`,
+    ].filter(Boolean).join(" | ").slice(0, 500);
+    return { ok: false, error: detail, candidates: [] };
   }
 }
 

--- a/scripts/generate-daily-content.js
+++ b/scripts/generate-daily-content.js
@@ -509,12 +509,23 @@ Return ONLY the JSON array, no markdown fencing, no explanation.`;
 async function main() {
   console.log(`\n📰 Generating daily content for ${today}\n`);
 
-  // Snapshot all data files before generation so we can restore on failure
+  // Snapshot all data files before generation so we can restore on failure.
+  // The snapshot covers every step that can mutate data/*.json: the generation
+  // loop, cross-category slug dedup, affiliate/Best Buy URL processing, and
+  // the final pre-commit schema validation. A failure in any of those is rolled
+  // back so the pipeline never leaves the repo in a partially-mutated state.
   const backups = {};
   for (const filename of Object.values(FILES)) {
     const fp = path.join(DATA_DIR, filename);
     backups[fp] = fs.readFileSync(fp, "utf8");
   }
+  const restoreBackups = () => {
+    console.log("Restoring data files from backup...");
+    for (const [fp, content] of Object.entries(backups)) {
+      fs.writeFileSync(fp, content);
+    }
+    console.log("Data files restored to pre-generation state.");
+  };
 
   try {
     for (const [category, filename] of Object.entries(FILES)) {
@@ -553,15 +564,13 @@ async function main() {
     }
   } catch (err) {
     console.error(`\n❌ Generation failed: ${err.message}`);
-    console.log("Restoring data files from backup...");
-    for (const [fp, content] of Object.entries(backups)) {
-      fs.writeFileSync(fp, content);
-    }
-    console.log("Data files restored to pre-generation state.");
+    restoreBackups();
     throw err;
   }
 
   console.log("✅ All categories updated.\n");
+
+  try {
 
   // Cross-category slug deduplication — all 5 files share the /item/<slug> route
   // Seed with archive slugs so new items never collide with archived URLs
@@ -722,7 +731,12 @@ async function main() {
   }
 
   console.log("🔍 Running pre-commit schema validation...");
-  runSchemaValidation();
+    runSchemaValidation();
+  } catch (err) {
+    console.error(`\n❌ Post-generation step failed: ${err.message}`);
+    restoreBackups();
+    throw err;
+  }
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary

Two small, defensive automation-reliability improvements aligned with the existing hardened posture. No success-path behavior change; fail-closed publishing gates and source allowlists untouched.

- **`scripts/generate-daily-content.js`** — backup snapshot at the top of `main()` was only restored if the *generation loop* threw. The post-generation block (cross-category slug dedup, Amazon/Best Buy URL processing, final `runSchemaValidation()`) ran outside the try/catch. A failure there left `data/*.json` half-mutated. Now a `restoreBackups()` helper is shared by a second try/catch wrapping the post-generation block, giving the whole pipeline atomic-restore semantics.
- **`scripts/automated-content-brain.mjs`** — when `daily-discovery.mjs` exits 0 but stdout fails to parse as JSON, only the parser's error was logged. stderr (where the spawned script's diagnostics live) was discarded. The catch now appends `stderr` tail and a `stdout[0..200]` snippet (capped at 500 chars total) so trending-live's decisionLog is self-diagnosing.

Diff: 2 files, +31 / -8.

The post-generation block keeps its original 2-space indent inside the new `try` block (JS is indent-agnostic). Prioritized a small reviewable diff over a 160-line re-indent.

## Validation

| Command | Result |
|---|---|
| `node --check` (both files) | ✅ |
| `node scripts/automated-content-brain.mjs --dry-run` | ✅ 14 candidates, 12 GitHub signals, 8 cleared threshold |
| `node scripts/validate-data.js` | ✅ 500 + 476 + 489 + 499 + 479 + 300 archived |
| `npx tsx --test scripts/current-event-engine.test.ts` | ✅ 8/8 |
| `npm run audit:all` | ✅ exit 0 (5 known PH-source warnings, 348 known generic-image warnings — both pre-existing data quality, out of scope) |
| `npm run build` | ✅ 2,769 pages |
| `npm run validate:seo` (strict) | ✅ 0 errors / 0 warnings |

## Test plan

- [x] Syntax check both modified scripts
- [x] Brain dry-run still produces a parseable trending payload
- [x] Full audit suite green
- [x] Static build produces expected page count
- [x] Strict SEO validator clean
- [ ] Daily Surfaced Edition workflow runs cleanly on next scheduled trigger (verify in CI)
- [ ] Trending Live Content workflow runs cleanly on next scheduled trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)