### PR TITLE
seo: add BreadcrumbList + ItemList JSON-LD to category hub pages

### DIFF
--- a/src/app/categories/page.tsx
+++ b/src/app/categories/page.tsx
@@ -3,12 +3,18 @@ import Link from "next/link";
 import { categories } from "@/lib/data";
 import { NewsletterForm } from "@/components/ui/NewsletterForm";
 import { buildMetadata } from "@/lib/seo";
+import { breadcrumbLd, ldScript } from "@/lib/jsonld";
 
 export const metadata: Metadata = buildMetadata({
   title: "Browse by Category",
   description: "Explore discoveries, products, tools, and hidden gems organized by topic.",
   path: "/categories",
 });
+
+const breadcrumbsLd = breadcrumbLd([
+  { name: "Home", href: "/" },
+  { name: "Categories" },
+]);
 
 const colorMap: Record<string, { bg: string; border: string; text: string; glow: string; dot: string }> = {
   indigo: {
@@ -38,6 +44,7 @@ export default function CategoriesPage() {
 
   return (
     <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={ldScript(breadcrumbsLd)} />
       <section className="relative py-20 sm:py-28 overflow-hidden">
         <div className="absolute inset-0 pointer-events-none">
           <div className="absolute -top-20 left-1/2 -translate-x-1/2 w-[560px] h-[560px] rounded-full bg-accent/8 blur-[130px]" />

--- a/src/app/discover/layout.tsx
+++ b/src/app/discover/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { discoveries } from "@/lib/data";
 import { buildMetadata } from "@/lib/seo";
+import { breadcrumbLd, itemListLd, ldScript } from "@/lib/jsonld";
 
 const count = discoveries.length;
 const title = "Fascinating Discoveries — Mind-Blowing Facts You Didn't Know";
@@ -13,6 +14,28 @@ export const metadata: Metadata = buildMetadata({
   absoluteTitle: true,
 });
 
+// Hub-page structured data: breadcrumbs help SERP rendering, the ItemList
+// surfaces the 30 newest items as a carousel-eligible list. Computed once at
+// module load — same data the page renders, so no drift.
+const HUB_NAME = "Discoveries";
+const breadcrumbsLd = breadcrumbLd([
+  { name: "Home", href: "/" },
+  { name: HUB_NAME },
+]);
+const listLd = itemListLd(
+  [...discoveries]
+    .sort((a, b) => (b.id || 0) - (a.id || 0))
+    .slice(0, 30)
+    .map((i) => ({ url: `/item/${i.slug}`, name: i.title })),
+  HUB_NAME,
+);
+
 export default function DiscoverLayout({ children }: { children: React.ReactNode }) {
-  return <>{children}</>;
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={ldScript(breadcrumbsLd)} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={ldScript(listLd)} />
+      {children}
+    </>
+  );
 }

--- a/src/app/future-radar/layout.tsx
+++ b/src/app/future-radar/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { futureRadar } from "@/lib/data";
 import { buildMetadata } from "@/lib/seo";
+import { breadcrumbLd, itemListLd, ldScript } from "@/lib/jsonld";
 
 const count = futureRadar.length;
 const title = "Future Technology & Emerging Innovations";
@@ -13,6 +14,25 @@ export const metadata: Metadata = buildMetadata({
   absoluteTitle: true,
 });
 
+const HUB_NAME = "Future Radar";
+const breadcrumbsLd = breadcrumbLd([
+  { name: "Home", href: "/" },
+  { name: HUB_NAME },
+]);
+const listLd = itemListLd(
+  [...futureRadar]
+    .sort((a, b) => (b.id || 0) - (a.id || 0))
+    .slice(0, 30)
+    .map((i) => ({ url: `/item/${i.slug}`, name: i.techName })),
+  HUB_NAME,
+);
+
 export default function FutureRadarLayout({ children }: { children: React.ReactNode }) {
-  return <>{children}</>;
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={ldScript(breadcrumbsLd)} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={ldScript(listLd)} />
+      {children}
+    </>
+  );
 }

--- a/src/app/hidden-gems/layout.tsx
+++ b/src/app/hidden-gems/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { hiddenGems } from "@/lib/data";
 import { buildMetadata } from "@/lib/seo";
+import { breadcrumbLd, itemListLd, ldScript } from "@/lib/jsonld";
 
 const count = hiddenGems.length;
 const title = "Hidden Gem Apps & Tools Most People Don't Know About";
@@ -13,6 +14,25 @@ export const metadata: Metadata = buildMetadata({
   absoluteTitle: true,
 });
 
+const HUB_NAME = "Hidden Gems";
+const breadcrumbsLd = breadcrumbLd([
+  { name: "Home", href: "/" },
+  { name: HUB_NAME },
+]);
+const listLd = itemListLd(
+  [...hiddenGems]
+    .sort((a, b) => (b.id || 0) - (a.id || 0))
+    .slice(0, 30)
+    .map((i) => ({ url: `/item/${i.slug}`, name: i.name })),
+  HUB_NAME,
+);
+
 export default function HiddenGemsLayout({ children }: { children: React.ReactNode }) {
-  return <>{children}</>;
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={ldScript(breadcrumbsLd)} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={ldScript(listLd)} />
+      {children}
+    </>
+  );
 }

--- a/src/app/tools/layout.tsx
+++ b/src/app/tools/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { dailyTools } from "@/lib/data";
 import { buildMetadata } from "@/lib/seo";
+import { breadcrumbLd, itemListLd, ldScript } from "@/lib/jsonld";
 
 const count = dailyTools.length;
 const title = "Best Daily Tools for Productivity, Design & Development";
@@ -13,6 +14,25 @@ export const metadata: Metadata = buildMetadata({
   absoluteTitle: true,
 });
 
+const HUB_NAME = "Daily Tools";
+const breadcrumbsLd = breadcrumbLd([
+  { name: "Home", href: "/" },
+  { name: HUB_NAME },
+]);
+const listLd = itemListLd(
+  [...dailyTools]
+    .sort((a, b) => (b.id || 0) - (a.id || 0))
+    .slice(0, 30)
+    .map((i) => ({ url: `/item/${i.slug}`, name: i.toolName })),
+  HUB_NAME,
+);
+
 export default function ToolsLayout({ children }: { children: React.ReactNode }) {
-  return <>{children}</>;
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={ldScript(breadcrumbsLd)} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={ldScript(listLd)} />
+      {children}
+    </>
+  );
 }

--- a/src/app/trending/layout.tsx
+++ b/src/app/trending/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { products } from "@/lib/data";
 import { buildMetadata } from "@/lib/seo";
+import { breadcrumbLd, itemListLd, ldScript } from "@/lib/jsonld";
 
 const count = products.length;
 const year = new Date().getUTCFullYear();
@@ -14,6 +15,25 @@ export const metadata: Metadata = buildMetadata({
   absoluteTitle: true,
 });
 
+const HUB_NAME = "Trending Products";
+const breadcrumbsLd = breadcrumbLd([
+  { name: "Home", href: "/" },
+  { name: HUB_NAME },
+]);
+const listLd = itemListLd(
+  [...products]
+    .sort((a, b) => (b.id || 0) - (a.id || 0))
+    .slice(0, 30)
+    .map((i) => ({ url: `/item/${i.slug}`, name: i.title })),
+  HUB_NAME,
+);
+
 export default function TrendingLayout({ children }: { children: React.ReactNode }) {
-  return <>{children}</>;
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={ldScript(breadcrumbsLd)} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={ldScript(listLd)} />
+      {children}
+    </>
+  );
 }


### PR DESCRIPTION
## Summary

Closes a structured-data gap on the five category hub pages and the categories index. Article/Product/Collection JSON-LD already covers item, collection, and live pages, but hub pages emitted nothing beyond the site-wide `WebSite` + `Organization` scripts in the root layout.

Each hub layout now emits two scripts at module load (no runtime cost, computed from the same data the page renders):

| Page | Added |
|---|---|
| `/discover` | `BreadcrumbList` (Home → Discoveries) + `ItemList` (30 newest discoveries) |
| `/hidden-gems` | `BreadcrumbList` (Home → Hidden Gems) + `ItemList` (30 newest gems) |
| `/future-radar` | `BreadcrumbList` (Home → Future Radar) + `ItemList` (30 newest tech) |
| `/tools` | `BreadcrumbList` (Home → Daily Tools) + `ItemList` (30 newest tools) |
| `/trending` | `BreadcrumbList` (Home → Trending Products) + `ItemList` (30 newest products) |
| `/categories` | `BreadcrumbList` (Home → Categories) only — page lists categories, not items |

Uses existing helpers (`breadcrumbLd`, `itemListLd`, `ldScript`) from [src/lib/jsonld.ts](src/lib/jsonld.ts), which already sanitize and stringify safely.

## Why it matters

**Priority 3 — high-confidence traffic improvement.**

- `BreadcrumbList` lets Google render breadcrumb trails in SERPs (replacing the raw URL), which historically lifts CTR by 10–30%.
- `ItemList` is carousel-eligible structured data for listing pages, used by Google for the \"things to consider\" / \"top picks\" rich results that surface from category landing pages.
- Both are static, computed once at module load — no hydration cost, no extra API calls, no drift versus what the page renders.

## Validation

| Command | Result |
|---|---|
| `node scripts/validate-data.js` | ✅ |
| `npm run build` | ✅ 2,769 pages |
| `npm run validate:seo` (strict) | ✅ 0 errors / 0 warnings |
| HTML inspection of 6 built pages | ✅ each hub has 4 ld+json scripts (WebSite + Organization + BreadcrumbList + ItemList); categories index has 3 (no ItemList). All JSON.parse pass. |

## Files changed

- [src/app/discover/layout.tsx](src/app/discover/layout.tsx)
- [src/app/hidden-gems/layout.tsx](src/app/hidden-gems/layout.tsx)
- [src/app/future-radar/layout.tsx](src/app/future-radar/layout.tsx)
- [src/app/tools/layout.tsx](src/app/tools/layout.tsx)
- [src/app/trending/layout.tsx](src/app/trending/layout.tsx)
- [src/app/categories/page.tsx](src/app/categories/page.tsx)

Net: +115 / -5 across 6 files. No CSS/component changes, no new dependencies.

## Test plan

- [x] Strict SEO validator clean
- [x] Each built HTML contains the expected scripts
- [x] All JSON-LD parses
- [ ] (Post-merge) Validate via [Google Rich Results Test](https://search.google.com/test/rich-results) on `/discover`, `/trending`, etc.

## Remaining risks / follow-up

- ItemList is capped at 30 entries to keep payload small (~3KB per hub). Bumping to 50 is trivial if Search Console suggests it.
- Could be DRYed into a `<CategoryHubJsonLd>` component, but the current per-layout pattern is simple, explicit, and matches the existing per-page JSON-LD style elsewhere.
- The `archive` page (if added later) would also benefit from a BreadcrumbList; not in scope for this pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)