### PR TITLE
fix(daily): unblock daily edition when category retries exhaust

### DIFF
--- a/scripts/generate-daily-content.js
+++ b/scripts/generate-daily-content.js
@@ -47,6 +47,13 @@ const REVIEW_TARGET_WORDS = 170;
 const API_RETRY_ATTEMPTS = 3;
 const API_RETRY_BASE_DELAY_MS = 5000;
 const API_RETRY_MAX_DELAY_MS = 45000;
+// Daily target per category. If retries exhaust without hitting TARGET_PER_CATEGORY,
+// publish what we have as long as it's at least MIN_PER_CATEGORY — the alternative
+// is the entire daily edition rolling back, which means no fresh content for any
+// category. Datasets are large enough (~480 items each) that a 3-or-4-item day
+// is a small dent vs. losing all five categories.
+const TARGET_PER_CATEGORY = 5;
+const MIN_PER_CATEGORY = 3;
 
 const BODY_FIELDS_BY_CATEGORY = {
   discoveries: ["shortDescription", "whyItIsInteresting"],
@@ -291,7 +298,15 @@ Requirements:
 
 async function generateItems(category, existingItems, count, seeds = []) {
   const existingSlugs = getExistingSlugs(existingItems);
-  const existingTitles = existingItems
+  // Send only the 100 most-recent existing titles to Gemini. Older items in
+  // archive/data are still enforced via the JS-side duplicate-name check below;
+  // this just prevents a 6KB+ token wall that the model down-weights anyway,
+  // and concentrates the "do not repeat" signal on the items most likely to
+  // collide with the model's regenerate-prone priors.
+  const recentExisting = [...existingItems]
+    .sort((a, b) => (b.id || 0) - (a.id || 0))
+    .slice(0, 100);
+  const existingTitles = recentExisting
     .map((i) => i.title || i.name || i.toolName || i.techName)
     .filter(Boolean)
     .join(", ");
@@ -403,7 +418,7 @@ ${formatSeeds(filteredSeeds)}
 
   const prompt = `${categoryPrompts[category]}
 ${seedBlock}
-EXISTING items to AVOID duplicating (these already exist): ${existingTitles}
+DO NOT propose any item whose name matches or closely resembles any of these — they are already published and will be rejected: ${existingTitles}
 
 Return EXACTLY ${count} items as a JSON array. Each item must match this exact schema:
 ${schemas[category]}
@@ -516,30 +531,39 @@ async function main() {
     backups[fp] = fs.readFileSync(fp, "utf8");
   }
 
+  const partialCategories = [];
   try {
     for (const [category, filename] of Object.entries(FILES)) {
-      console.log(`[${category}] Generating 5 new items...`);
+      console.log(`[${category}] Generating ${TARGET_PER_CATEGORY} new items...`);
       const existing = readJSON(filename);
       const seeds = await getSeedsForCategory(category);
       if (seeds.length) {
         console.log(`[${category}] Seeded with ${seeds.length} real trending items (${[...new Set(seeds.map((s) => s.source))].join(", ")})`);
       }
       const newItems = [];
-      for (let attempt = 1; newItems.length < 5 && attempt <= 5; attempt++) {
-        const needed = 5 - newItems.length;
+      for (let attempt = 1; newItems.length < TARGET_PER_CATEGORY && attempt <= 5; attempt++) {
+        const needed = TARGET_PER_CATEGORY - newItems.length;
         const seedsForAttempt = attempt === 1 ? seeds : [];
         if (attempt === 2 && seeds.length) {
           console.warn(`[${category}] Falling back to unseeded generation for remaining item(s).`);
         }
-        const requestCount = seedsForAttempt.length ? needed : 5;
+        const requestCount = seedsForAttempt.length ? needed : TARGET_PER_CATEGORY;
         const batch = await generateItems(category, [...existing, ...newItems], requestCount, seedsForAttempt);
         newItems.push(...batch.slice(0, needed));
-        if (newItems.length < 5) {
-          console.warn(`[${category}] ${newItems.length}/5 valid items after attempt ${attempt}; retrying for ${5 - newItems.length} item(s).`);
+        if (newItems.length < TARGET_PER_CATEGORY) {
+          console.warn(`[${category}] ${newItems.length}/${TARGET_PER_CATEGORY} valid items after attempt ${attempt}; retrying for ${TARGET_PER_CATEGORY - newItems.length} item(s).`);
         }
       }
-      if (newItems.length < 5) {
-        throw new Error(`[${category}] only generated ${newItems.length}/5 valid items with at least ${REVIEW_MIN_WORDS} body words`);
+      if (newItems.length < MIN_PER_CATEGORY) {
+        // Below floor — failure mode unchanged: throw, restore backups, alert.
+        throw new Error(`[${category}] only generated ${newItems.length}/${TARGET_PER_CATEGORY} valid items (floor is ${MIN_PER_CATEGORY}) with at least ${REVIEW_MIN_WORDS} body words`);
+      }
+      if (newItems.length < TARGET_PER_CATEGORY) {
+        // Between floor and target — accept partial run instead of failing the
+        // whole edition. This category is saturated for today; tomorrow's run
+        // will try again with rotated seeds.
+        partialCategories.push({ category, generated: newItems.length });
+        console.warn(`[${category}] ⚠ Accepting partial run: ${newItems.length}/${TARGET_PER_CATEGORY} valid items (≥${MIN_PER_CATEGORY} floor). Dataset will shrink by ${TARGET_PER_CATEGORY - newItems.length} item(s) this run.`);
       }
       console.log(
         `[${category}] Generated: ${newItems.map((i) => i.slug).join(", ")}`
@@ -561,6 +585,14 @@ async function main() {
     throw err;
   }
 
+  if (partialCategories.length > 0) {
+    console.log(
+      `⚠ ${partialCategories.length} categor${partialCategories.length === 1 ? "y" : "ies"} accepted with partial item counts:`,
+    );
+    for (const { category, generated } of partialCategories) {
+      console.log(`   - ${category}: ${generated}/${TARGET_PER_CATEGORY}`);
+    }
+  }
   console.log("✅ All categories updated.\n");
 
   // Cross-category slug deduplication — all 5 files share the /item/<slug> route

--- a/scripts/lib/signal-sources.js
+++ b/scripts/lib/signal-sources.js
@@ -293,8 +293,16 @@ async function getSeedsForCategory(category) {
       return [...show, ...hn].slice(0, 8);
     }
     case "daily-tools": {
-      const [gh, ph] = await Promise.all([fetchGitHubTrending({ limit: 6 }), fetchProductHunt({ limit: 4 })]);
-      return [...gh, ...ph].slice(0, 8);
+      // Widen the GitHub seed pool: more candidates (10 vs 6) over a longer
+      // window (30 vs 14 days) so daily generation has alternatives when the
+      // last week's trending repos are already covered. The 479-item dataset
+      // saturates common-tool space quickly, so a broader signal pool reduces
+      // the duplicate-skip rate and the resulting retry exhaustion.
+      const [gh, ph] = await Promise.all([
+        fetchGitHubTrending({ limit: 10, daysBack: 30 }),
+        fetchProductHunt({ limit: 4 }),
+      ]);
+      return [...gh, ...ph].slice(0, 12);
     }
     case "future-radar": {
       return fetchHackerNews({ limit: 6, minScore: 150 });


### PR DESCRIPTION
## Summary

Today's Daily Surfaced Edition ([run 25495699045](https://github.com/Aveniqa/discover-platform/actions/runs/25495699045)) failed: the `daily-tools` category exhausted 5 retries against Gemini because most well-known tools (Notion / Obsidian / Raycast / Logseq / Anki / Canva / Todoist / DeepL etc.) already exist in the 479-item dataset, so seeded + unseeded generation kept proposing them — all correctly rejected by the duplicate-name detector. **Daily-edition history: last 10 runs are 9 failures + 1 success, all the same shape.**

Three coordinated fixes, all in scripts/* — no architecture, build, or UI changes:

### 1. Partial-accept floor (R1) — `scripts/generate-daily-content.js`
Replace the strict \"5/5 or restore-and-fail\" rule with a 3-of-5 floor. Categories that miss target after 5 attempts but cleared the floor publish what they have; **below the floor still throws and triggers the existing backup-restore** (PR #66). New end-of-run summary lists categories accepted with partial counts.

### 2. Wider GitHub seed pool for `daily-tools` (R2) — `scripts/lib/signal-sources.js`
Daily-tools branch now requests `limit:10 daysBack:30` (was `6/14`). Combined cap raised `8 → 12` to keep PH seeds alongside. The 14-day window was returning the same trending repos we covered last week.

### 3. Recent-100 prompt cap + stronger wording (R3) — `scripts/generate-daily-content.js`
Send only the **100 most-recent** existing titles to Gemini (sorted by id desc) instead of all ~480. The full duplicate-name check still runs against everything in JS — this just stops the prompt from blowing past ~6KB of \"avoid these\" tokens that the model demonstrably down-weights. Wording also strengthened: \"AVOID duplicating\" → \"DO NOT propose any item ... they are already published and will be rejected\".

## Why these three together

R1 alone gives operational unblock but does nothing about the underlying generation quality. R2+R3 alone might not be enough on a particularly saturated day. Together they:

- (R2 + R3) reduce the rate of duplicate-rejections per attempt
- (R1) absorbs the residual when reduction isn't enough
- (R1's floor) preserves the fail-closed gate when generation quality is genuinely broken

## Validation

| Command | Result |
|---|---|
| `node --check` (both scripts) | ✅ |
| `node scripts/validate-data.js` | ✅ |
| `npm run audit:automated` | ✅ |
| `node scripts/validate-current-events.mjs` (via audit:automated) | ✅ |
| `npm run build` | ✅ 2,769 pages |
| `npm run validate:seo` (strict, via postbuild) | ✅ 0 errors / 0 warnings |
| In-process simulation: happy / 4-of-5 partial / 3-of-5 partial / 2-of-5 floor-breach / 0-of-5 floor-breach / late recovery | ✅ all paths as designed |
| Live GitHub API: baseline (`limit:6 daysBack:14`) returns 6 repos (1 already covered); new (`limit:10 daysBack:30`) returns 10 distinct emerging repos | ✅ |

## Files changed

- [scripts/generate-daily-content.js](scripts/generate-daily-content.js) — +44 / −8
- [scripts/lib/signal-sources.js](scripts/lib/signal-sources.js) — +9 / −3

Net: 2 files, +53 / −11. No architecture, build, or UI changes.

## Risks

- **Dataset slowly shrinks on saturated days.** A category accepting 3/5 items removes 5 (rotation) and adds 3 (generation), net −2. Over a sustained string of partial days, dataset size could drift down. Acceptable: ~480 items each is far above any minimum that affects browsing UX or page counts; tomorrow's run will retry with rotated seeds. If sustained drift becomes visible we can lower the rotation count instead.
- **R3 doesn't fully eliminate model-prior bias.** A model with Notion baked into its priors will still propose Notion sometimes, even with prompt instructions. The duplicate-name detector still catches it; R3 just makes those rejections less frequent.

## Test plan

- [x] Syntax checks pass on both scripts
- [x] All baseline validators pass
- [x] Build green
- [x] Partial-accept loop covered by simulation
- [x] Wider seed pool returns distinct, non-overlapping repos against current dataset
- [ ] (Post-merge) Watch tomorrow's Daily Surfaced Edition run for either a clean 5/5/5/5/5 or a controlled partial-accept

## Compatibility

- Compatible with PR #66 (extends the same try/catch path; no overlap of edits within the same code).
- Compatible with PR #67 (RSS thumbnails) and PR #68 (category JSON-LD) — disjoint files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)