### PR TITLE
feat(theme): restore light mode with toggle in nav

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,32 +1,35 @@
 @import "tailwindcss";
 
+/* Custom variant for theme switching — use as `light:bg-...` */
+@custom-variant light (&:where([data-theme="light"], [data-theme="light"] *));
+
 /* ============================================
    SURFACED — Premium Design System v2
    Elevated visual language for discovery
    ============================================ */
 
 @theme inline {
-  /* ---- Color Palette (Vivid + Luminous) ---- */
-  --color-background: #08080C;
-  --color-surface: #0F0F14;
-  --color-surface-elevated: #17171F;
-  --color-surface-hover: #1E1E28;
-  --color-border: #22222E;
-  --color-border-subtle: #18181F;
-  --color-foreground: #F2F2F7;
-  --color-muted: #8E8EA0;
-  --color-muted-foreground: #6E6E82;
-  --color-accent: #A855F7;
-  --color-accent-hover: #C084FC;
-  --color-accent-glow: rgba(168, 85, 247, 0.2);
-  --color-cyan: #22D3EE;
-  --color-cyan-glow: rgba(34, 211, 238, 0.15);
-  --color-amber: #FBBF24;
-  --color-amber-glow: rgba(251, 191, 36, 0.15);
-  --color-emerald: #34D399;
-  --color-rose: #FB7185;
-  --color-card: #0D0D12;
-  --color-card-hover: #141419;
+  /* ---- Color Palette — values come from the [data-theme] blocks below ---- */
+  --color-background: var(--bg);
+  --color-surface: var(--surface);
+  --color-surface-elevated: var(--surface-elevated);
+  --color-surface-hover: var(--surface-hover);
+  --color-border: var(--border);
+  --color-border-subtle: var(--border-subtle);
+  --color-foreground: var(--fg);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-fg);
+  --color-accent: var(--accent);
+  --color-accent-hover: var(--accent-hover);
+  --color-accent-glow: var(--accent-glow);
+  --color-cyan: var(--cyan);
+  --color-cyan-glow: var(--cyan-glow);
+  --color-amber: var(--amber);
+  --color-amber-glow: var(--amber-glow);
+  --color-emerald: var(--emerald);
+  --color-rose: var(--rose);
+  --color-card: var(--card);
+  --color-card-hover: var(--card-hover);
 
   /* ---- Typography ---- */
   --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system, sans-serif;
@@ -58,6 +61,80 @@
   --animate-shimmer: shimmer 2.5s ease-in-out infinite;
   --animate-gradient: gradient-shift 8s ease infinite;
   --animate-breathe: breathe 4s ease-in-out infinite;
+}
+
+/* ============================================
+   Theme Tokens — Dark (default) + Light
+   ============================================ */
+:root,
+[data-theme="dark"] {
+  --bg: #08080C;
+  --surface: #0F0F14;
+  --surface-elevated: #17171F;
+  --surface-hover: #1E1E28;
+  --border: #22222E;
+  --border-subtle: #18181F;
+  --fg: #F2F2F7;
+  --muted: #8E8EA0;
+  --muted-fg: #6E6E82;
+  --accent: #A855F7;
+  --accent-hover: #C084FC;
+  --accent-glow: rgba(168, 85, 247, 0.2);
+  --cyan: #22D3EE;
+  --cyan-glow: rgba(34, 211, 238, 0.15);
+  --amber: #FBBF24;
+  --amber-glow: rgba(251, 191, 36, 0.15);
+  --emerald: #34D399;
+  --rose: #FB7185;
+  --card: #0D0D12;
+  --card-hover: #141419;
+
+  /* Surface-dependent effects */
+  --glass-bg: rgba(15, 15, 20, 0.75);
+  --glass-bg-strong: rgba(15, 15, 20, 0.88);
+  --scrollbar-track: transparent;
+  --scrollbar-thumb: #22222E;
+  --selection-bg: rgba(168, 85, 247, 0.35);
+  --selection-fg: #F2F2F7;
+  --shadow-ring: rgba(34, 34, 46, 0.7);
+  --shadow-drop: rgba(0, 0, 0, 0.5);
+  --shadow-drop-light: rgba(0, 0, 0, 0.4);
+  --noise-opacity: 0.018;
+}
+
+[data-theme="light"] {
+  --bg: #FAFAF7;
+  --surface: #FFFFFF;
+  --surface-elevated: #F4F4EE;
+  --surface-hover: #EDEDE5;
+  --border: #E4E4DA;
+  --border-subtle: #F0F0E8;
+  --fg: #1A1A1F;
+  --muted: #6E6E7A;
+  --muted-fg: #8A8A95;
+  --accent: #7C3AED;
+  --accent-hover: #6D28D9;
+  --accent-glow: rgba(124, 58, 237, 0.18);
+  --cyan: #0891B2;
+  --cyan-glow: rgba(8, 145, 178, 0.14);
+  --amber: #D97706;
+  --amber-glow: rgba(217, 119, 6, 0.14);
+  --emerald: #059669;
+  --rose: #E11D48;
+  --card: #FFFFFF;
+  --card-hover: #F7F7F2;
+
+  /* Surface-dependent effects */
+  --glass-bg: rgba(255, 255, 255, 0.75);
+  --glass-bg-strong: rgba(255, 255, 255, 0.88);
+  --scrollbar-track: transparent;
+  --scrollbar-thumb: #D4D4CA;
+  --selection-bg: rgba(124, 58, 237, 0.22);
+  --selection-fg: #1A1A1F;
+  --shadow-ring: rgba(0, 0, 0, 0.08);
+  --shadow-drop: rgba(0, 0, 0, 0.08);
+  --shadow-drop-light: rgba(0, 0, 0, 0.05);
+  --noise-opacity: 0.012;
 }
 
 /* ============================================
@@ -115,25 +192,28 @@
    ============================================ */
 * {
   scrollbar-width: thin;
-  scrollbar-color: #22222E transparent;
+  scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
 }
 
 html {
   scroll-behavior: smooth;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background: var(--bg);
+  color: var(--fg);
 }
 
 body {
-  background: #08080C;
-  color: #F2F2F7;
+  background: var(--bg);
+  color: var(--fg);
   font-family: "Inter", ui-sans-serif, system-ui, -apple-system, sans-serif;
   line-height: 1.65;
+  transition: background-color 0.25s ease, color 0.25s ease;
 }
 
 ::selection {
-  background: rgba(168, 85, 247, 0.35);
-  color: #F2F2F7;
+  background: var(--selection-bg);
+  color: var(--selection-fg);
 }
 
 /* ---- Premium Scrollbar ---- */
@@ -142,16 +222,16 @@ body {
 }
 
 ::-webkit-scrollbar-track {
-  background: transparent;
+  background: var(--scrollbar-track);
 }
 
 ::-webkit-scrollbar-thumb {
-  background: #22222E;
+  background: var(--scrollbar-thumb);
   border-radius: 10px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: #A855F7;
+  background: var(--accent);
 }
 
 /* ============================================
@@ -202,13 +282,13 @@ body {
    Glass Effects
    ============================================ */
 .glass {
-  background: rgba(15, 15, 20, 0.75);
+  background: var(--glass-bg);
   backdrop-filter: blur(24px) saturate(1.2);
   -webkit-backdrop-filter: blur(24px) saturate(1.2);
 }
 
 .glass-strong {
-  background: rgba(15, 15, 20, 0.88);
+  background: var(--glass-bg-strong);
   backdrop-filter: blur(40px) saturate(1.3);
   -webkit-backdrop-filter: blur(40px) saturate(1.3);
 }
@@ -218,16 +298,16 @@ body {
    ============================================ */
 .premium-shadow {
   box-shadow:
-    0 0 0 1px rgba(34, 34, 46, 0.7),
-    0 4px 32px rgba(0, 0, 0, 0.5),
-    0 1px 4px rgba(0, 0, 0, 0.4);
+    0 0 0 1px var(--shadow-ring),
+    0 4px 32px var(--shadow-drop),
+    0 1px 4px var(--shadow-drop-light);
 }
 
 .premium-glow {
   box-shadow:
-    0 0 0 1px rgba(168, 85, 247, 0.2),
-    0 0 40px rgba(168, 85, 247, 0.1),
-    0 4px 32px rgba(0, 0, 0, 0.4);
+    0 0 0 1px var(--accent-glow),
+    0 0 40px var(--accent-glow),
+    0 4px 32px var(--shadow-drop-light);
 }
 
 /* ============================================
@@ -238,11 +318,11 @@ body {
 }
 
 .card-hover-glow:hover {
-  border-color: rgba(168, 85, 247, 0.25);
+  border-color: color-mix(in srgb, var(--accent) 25%, transparent);
   box-shadow:
-    0 0 0 1px rgba(168, 85, 247, 0.12),
-    0 0 50px rgba(168, 85, 247, 0.07),
-    0 8px 40px rgba(0, 0, 0, 0.5);
+    0 0 0 1px color-mix(in srgb, var(--accent) 12%, transparent),
+    0 0 50px color-mix(in srgb, var(--accent) 7%, transparent),
+    0 8px 40px var(--shadow-drop);
   transform: translateY(-3px);
 }
 
@@ -452,7 +532,7 @@ body {
   position: fixed;
   inset: 0;
   background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
-  opacity: 0.018;
+  opacity: var(--noise-opacity);
   pointer-events: none;
   z-index: 9999;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -83,8 +83,16 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" className={`${inter.variable} dark`}>
+    <html lang="en" className={inter.variable} suppressHydrationWarning>
       <head>
+        {/* Flash-prevent: read theme before paint so the page never starts in
+            the wrong palette and flickers on hydration. Falls back to OS pref
+            on first visit, then localStorage. */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){try{var s=localStorage.getItem('theme');var p=window.matchMedia('(prefers-color-scheme: light)').matches?'light':'dark';var t=(s==='light'||s==='dark')?s:p;document.documentElement.setAttribute('data-theme',t);}catch(e){document.documentElement.setAttribute('data-theme','dark');}})();`,
+          }}
+        />
         <meta name="impact-site-verification" content="1dd3812c-2540-4b06-b6c6-27528553b44d" />
         <Analytics />
         <link rel="alternate" type="application/rss+xml" title="Surfaced" href="/feed.xml" />

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -9,6 +9,7 @@ import { SearchTrigger } from "@/components/ui/SearchModal";
 import { BookmarkCount } from "@/components/ui/BookmarkCount";
 import { SurpriseMe } from "@/components/ui/SurpriseMe";
 import { StreakWidget } from "@/components/ui/StreakWidget";
+import { ThemeToggle } from "@/components/ui/ThemeToggle";
 
 /** Maps item type slugs (used in URL /item/…) to their parent nav paths */
 const typeToNavPath: Record<string, string> = {
@@ -152,6 +153,9 @@ export function Navbar() {
 
               {/* Bookmark Count */}
               <BookmarkCount />
+
+              {/* Theme Toggle */}
+              <ThemeToggle />
 
               {/* Mobile Menu Toggle */}
               <button

--- a/src/components/ui/ThemeToggle.tsx
+++ b/src/components/ui/ThemeToggle.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type Theme = "light" | "dark";
+
+function readTheme(): Theme {
+  if (typeof document === "undefined") return "dark";
+  const attr = document.documentElement.getAttribute("data-theme");
+  return attr === "light" ? "light" : "dark";
+}
+
+export function ThemeToggle() {
+  const [theme, setTheme] = useState<Theme>("dark");
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    setTheme(readTheme());
+  }, []);
+
+  const toggle = () => {
+    const next: Theme = theme === "dark" ? "light" : "dark";
+    setTheme(next);
+    document.documentElement.setAttribute("data-theme", next);
+    try {
+      localStorage.setItem("theme", next);
+    } catch {}
+  };
+
+  const isLight = mounted && theme === "light";
+  const label = isLight ? "Switch to dark mode" : "Switch to light mode";
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-label={label}
+      title={label}
+      className="flex items-center justify-center w-9 h-9 rounded-lg text-muted-foreground hover:text-foreground hover:bg-surface-elevated transition-colors cursor-pointer"
+    >
+      {/* Sun icon (shown in dark mode → click to go light) */}
+      <svg
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.75"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+        className={isLight ? "hidden" : "block"}
+      >
+        <circle cx="12" cy="12" r="4" />
+        <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+      </svg>
+      {/* Moon icon (shown in light mode → click to go dark) */}
+      <svg
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.75"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+        className={isLight ? "block" : "hidden"}
+      >
+        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+      </svg>
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary

Light mode was originally added in `02f6908` on `claude/design-seo-phases-1-5` (PR #26) but that branch never merged and has since gone stale/conflicting. Main has been dark-only the whole time. This PR restores **just the theme system** without pulling in the rest of PR #26's bundled design-phase changes.

Four files, all minimal:

| File | Change |
|---|---|
| `src/components/ui/ThemeToggle.tsx` (new) | Sun/moon button. Reads + writes `data-theme` attr on `<html>` and persists to `localStorage`. |
| `src/app/globals.css` | `@theme inline` colors now reference CSS vars. New `:root,[data-theme=\"dark\"]` and `[data-theme=\"light\"]` blocks hold the palette values. `body` / scrollbar / selection / glass / shadows all use `var()` so they swap automatically. |
| `src/app/layout.tsx` | Drops hardcoded `dark` className; adds `suppressHydrationWarning` and a tiny inline flash-prevent script that runs before paint (reads localStorage, falls back to `prefers-color-scheme`, sets `data-theme`). |
| `src/components/layout/Navbar.tsx` | Imports `ThemeToggle` and renders it next to the bookmark count. |

Net: 4 files, +210 / −43.

## Visual verification

Verified via `npx serve out` and the preview MCP tool:

| Step | Result |
|---|---|
| Default page load | `data-theme=\"dark\"`, bg `#08080C`, fg `#F2F2F7` ✅ |
| Click toggle | `data-theme=\"light\"`, bg `#FAFAF7`, fg `#1A1A1F`, accent flips `#A855F7 → #7C3AED` ✅ |
| Click back | Returns to dark cleanly ✅ |
| Set `localStorage.theme=light`, reload | Page comes up in light without flicker (flash-prevent script works) ✅ |
| `preview_console_logs --level error` | No errors in either mode |

Light-mode screenshot inline ↓ (warm off-white bg, dark fg, accent + cyan still pop, moon icon shown for the 'switch to dark' action):

(captured during verification — see commit message for the full sequence)

## Validation

| Command | Result |
|---|---|
| `node scripts/validate-data.js` | ✅ |
| `npm run build` | ✅ 2,769 pages |
| `npm run validate:seo` (strict) | ✅ 0 errors / 0 warnings |
| Browser preview, both themes, hard reload | ✅ |

## Scope and tradeoffs

- **No per-component `light:bg-...` Tailwind overrides** from PR #26's polish sweep. Tokens (`bg-background`, `text-foreground`, `border-border`, `text-muted`, etc.) flip automatically because they're now `var()` driven. Components that hardcode raw Tailwind colors like `text-amber-400` will stay as-is in both modes — visually fine in most places but a follow-up polish pass can tighten edge cases incrementally.
- The flash-prevent script is 1 line. It honors localStorage first, then OS preference, defaulting to dark on any error.
- Compatible with PR #66 / #67 / #68 / #70 — disjoint files in all cases.

## Test plan

- [x] Both themes verified visually in static export
- [x] Flash-prevent honors persisted choice across reload
- [x] No console errors
- [x] Build clean
- [ ] (Post-merge) Spot-check on a few item pages and category pages in light mode to identify any obviously-broken hardcoded colors worth a follow-up polish

🤖 Generated with [Claude Code](https://claude.com/claude-code)