### PR TITLE
fix(newsletter): filter NWS weather alerts from breaking-news drafts

### DIFF
--- a/scripts/send-breaking-news-draft.mjs
+++ b/scripts/send-breaking-news-draft.mjs
@@ -12,9 +12,36 @@ const DRAFTS_FILE = join(AUTOMATED_DIR, "newsletter-drafts.json");
 const API_KEY = process.env.BUTTONDOWN_API_KEY;
 const BASE_URL = "https://surfaced-x.pages.dev";
 const MAJOR_STORY_THRESHOLD = Number(process.env.BREAKING_NEWS_THRESHOLD || 92);
+// NWS weather alerts routinely score >=92 (Tornado / Flash Flood / Severe
+// Thunderstorm / Red Flag / Extreme Heat / etc.) and were creating multiple
+// breaking-news drafts per day for events that don't fit Surfaced's
+// discovery/products/gems editorial voice. Filtered out by default; set
+// BREAKING_NEWS_ALLOW_WEATHER=true to re-enable.
+const ALLOW_WEATHER_DRAFTS = process.env.BREAKING_NEWS_ALLOW_WEATHER === "true";
 const API_RETRY_ATTEMPTS = 3;
 const API_RETRY_BASE_DELAY_MS = 1500;
 const API_RETRY_MAX_DELAY_MS = 12000;
+
+/**
+ * Weather alert detection — matches NWS-issued alerts based on source identity.
+ * Source URL is the most reliable signal (api.weather.gov / weather.gov), with
+ * sourceName + title heuristics as belt-and-braces.
+ */
+function isWeatherAlert(item) {
+  const sourceUrl = String(item.sourceUrl || "").toLowerCase();
+  if (sourceUrl.includes("weather.gov")) return true;
+  const sourceName = String(item.sourceName || "").toLowerCase();
+  if (sourceName.includes("national weather service") || sourceName === "nws") return true;
+  // Source-trail entries can also identify NWS even if the primary source
+  // was rewritten by enrichment.
+  for (const entry of item.sourceTrail || []) {
+    const url = String(entry?.url || "").toLowerCase();
+    const name = String(entry?.name || entry?.label || "").toLowerCase();
+    if (url.includes("weather.gov")) return true;
+    if (name.includes("national weather service")) return true;
+  }
+  return false;
+}
 
 function readJson(path, fallback) {
   if (!existsSync(path)) return fallback;
@@ -96,9 +123,17 @@ function pickMajorStory() {
       sourceUrl: item.sourceUrl,
       sourceTrail: item.sourceTrail || [],
     }));
-  return [...events, ...trending]
-    .filter((item) => item.score >= MAJOR_STORY_THRESHOLD)
-    .sort((a, b) => b.score - a.score)[0] || null;
+  const candidates = [...events, ...trending].filter(
+    (item) => item.score >= MAJOR_STORY_THRESHOLD,
+  );
+  const filtered = ALLOW_WEATHER_DRAFTS
+    ? candidates
+    : candidates.filter((item) => !isWeatherAlert(item));
+  const skipped = candidates.length - filtered.length;
+  if (skipped > 0) {
+    console.log(`Filtered ${skipped} weather alert(s) from breaking-news draft pool. Set BREAKING_NEWS_ALLOW_WEATHER=true to allow.`);
+  }
+  return filtered.sort((a, b) => b.score - a.score)[0] || null;
 }
 
 function buildDraftHtml(story) {

--- a/scripts/send-breaking-news-draft.mjs
+++ b/scripts/send-breaking-news-draft.mjs
@@ -23,21 +23,35 @@ const API_RETRY_BASE_DELAY_MS = 1500;
 const API_RETRY_MAX_DELAY_MS = 12000;
 
 /**
+ * Hostname-bounded URL match. Avoids the substring-sanitization pitfall where
+ * `https://attacker.com/?fake=weather.gov`.includes("weather.gov") would be
+ * true. We require an exact hostname match or a proper subdomain (suffix
+ * preceded by a dot).
+ */
+function urlHostMatches(url, hostSuffix) {
+  try {
+    const host = new URL(url).hostname.toLowerCase();
+    const target = hostSuffix.toLowerCase();
+    return host === target || host.endsWith("." + target);
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Weather alert detection — matches NWS-issued alerts based on source identity.
  * Source URL is the most reliable signal (api.weather.gov / weather.gov), with
- * sourceName + title heuristics as belt-and-braces.
+ * sourceName heuristics as belt-and-braces.
  */
 function isWeatherAlert(item) {
-  const sourceUrl = String(item.sourceUrl || "").toLowerCase();
-  if (sourceUrl.includes("weather.gov")) return true;
+  if (urlHostMatches(item.sourceUrl, "weather.gov")) return true;
   const sourceName = String(item.sourceName || "").toLowerCase();
   if (sourceName.includes("national weather service") || sourceName === "nws") return true;
   // Source-trail entries can also identify NWS even if the primary source
   // was rewritten by enrichment.
   for (const entry of item.sourceTrail || []) {
-    const url = String(entry?.url || "").toLowerCase();
+    if (urlHostMatches(entry?.url, "weather.gov")) return true;
     const name = String(entry?.name || entry?.label || "").toLowerCase();
-    if (url.includes("weather.gov")) return true;
     if (name.includes("national weather service")) return true;
   }
   return false;


### PR DESCRIPTION
## Summary

NWS weather alerts (Tornado / Severe Thunderstorm / Flash Flood / Red Flag / Extreme Heat / etc.) routinely score ≥92 in the editorial scorer and were producing 5–6 Buttondown breaking-news drafts per day for events that don't fit Surfaced's discovery/products/gems voice. **11 drafts in 2 days, 100% weather alerts** at the time of audit.

Drafts are fail-soft (never auto-sent), so this was editorial signal noise rather than a delivery problem — but the noise was crowding out legitimate breaking-news candidates from non-weather sources.

## What changed

`scripts/send-breaking-news-draft.mjs` filters weather-alert candidates out of the breaking-news draft pool by default. Detection:
- `sourceUrl` contains `weather.gov`
- `sourceName` contains \"national weather service\" / \"nws\"
- any `sourceTrail` entry matches either of the above

**Opt back in with `BREAKING_NEWS_ALLOW_WEATHER=true`** if a significant national weather event needs to be highlighted.

Operators see a one-line log: `Filtered N weather alert(s) from breaking-news draft pool. Set BREAKING_NEWS_ALLOW_WEATHER=true to allow.` so the filter behavior is observable.

## Why it matters

Surfaced subscribers signed up for fresh discoveries, trending products, hidden gems, and future tech — not regional NWS alerts. Editorial trust improves when the breaking-news channel reflects the site's actual voice.

The publishing gate (`score >= MAJOR_STORY_THRESHOLD`, default 92) is unchanged. Source allowlists, fail-closed gates, and Buttondown live-send/draft fallback are untouched.

## Local verification

Ran the script against current `automated-content/*` files:
```
Filtered 2 weather alert(s) from breaking-news draft pool. Set BREAKING_NEWS_ALLOW_WEATHER=true to allow.
Draft already exists for candidate-cpsc-26444; skipping.
```

After filtering, the script picked a **CPSC product-recall** candidate as the next major story — a far better editorial fit. The CPSC draft already existed in `newsletter-drafts.json`, so the script correctly skipped without re-creating it.

## Validation

| Command | Result |
|---|---|
| `node --check scripts/send-breaking-news-draft.mjs` | ✅ |
| `node scripts/validate-data.js` | ✅ |
| `npm run audit:automated` | ✅ |
| `npm run build` | ✅ 2,769 pages |
| `npm run validate:seo` (strict, postbuild) | ✅ 0 errors / 0 warnings |

## Files changed

[scripts/send-breaking-news-draft.mjs](scripts/send-breaking-news-draft.mjs) — +38 / −3 (one new helper `isWeatherAlert`, one constant `ALLOW_WEATHER_DRAFTS`, filter step in `pickMajorStory`).

## Test plan

- [x] Local simulation against current automated-content
- [x] Build clean
- [ ] (Post-merge) Watch next trending-live run → no NWS draft should be created; non-weather candidates that score ≥92 should still draft as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)