### PR TITLE
chore: workflow reliability + efficiency hardening (F1–F6 bundle)

### DIFF
--- a/.github/workflows/daily-edition.yml
+++ b/.github/workflows/daily-edition.yml
@@ -121,8 +121,20 @@ jobs:
             exit 0
           fi
           git commit -m "📰 Daily edition: $(date +%Y-%m-%d)"
-          git pull --rebase --autostash origin main
-          git push
+          # Retry push up to 3x — trending-live and social-posts can push
+          # from parallel workflows; a transient race must not waste a 30-min
+          # Gemini-call generation run.
+          for attempt in 1 2 3; do
+            git pull --rebase --autostash origin main
+            if git push; then
+              echo "Push succeeded on attempt $attempt"
+              exit 0
+            fi
+            echo "Push attempt $attempt failed; retrying in $((attempt * 5))s..."
+            sleep $((attempt * 5))
+          done
+          echo "Push failed after 3 attempts"
+          exit 1
 
   alert-on-failure:
     runs-on: ubuntu-latest

--- a/.github/workflows/data-backup.yml
+++ b/.github/workflows/data-backup.yml
@@ -27,9 +27,13 @@ jobs:
           mkdir -p /tmp/backup
           ARCHIVE="/tmp/backup/data-snapshot-${DATE}.tar.gz"
 
-          # Include all JSON data files + image cache
+          # Include all JSON data files, the image cache, and the live
+          # automated-content feeds (current-events, trending-live, drafts).
+          # Trending-live updates 8x/day so its history isn't otherwise
+          # recoverable without trawling the git log.
           tar -czf "$ARCHIVE" \
             data/*.json \
+            automated-content/*.json \
             public/feed.xml 2>/dev/null || true
 
           # Output archive path and size

--- a/.github/workflows/social-posts.yml
+++ b/.github/workflows/social-posts.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: '22'
+          cache: 'npm'
 
       - name: Generate social media posts
         env:
@@ -62,8 +63,18 @@ jobs:
             exit 0
           fi
           git commit -m "📱 Social posts: $(date +%Y-%m-%d)"
-          git pull --rebase --autostash origin main
-          git push
+          # Retry push up to 3x — see daily-edition.yml for rationale.
+          for attempt in 1 2 3; do
+            git pull --rebase --autostash origin main
+            if git push; then
+              echo "Push succeeded on attempt $attempt"
+              exit 0
+            fi
+            echo "Push attempt $attempt failed; retrying in $((attempt * 5))s..."
+            sleep $((attempt * 5))
+          done
+          echo "Push failed after 3 attempts"
+          exit 1
 
   alert-on-failure:
     runs-on: ubuntu-latest

--- a/.github/workflows/trending-live.yml
+++ b/.github/workflows/trending-live.yml
@@ -49,6 +49,9 @@ jobs:
         if: steps.brain.outputs.changed == 'true'
         env:
           YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
+        # YouTube API has a daily quota and occasional capacity flakes.
+        # Enrichment is opportunistic — items still publish without videos.
+        continue-on-error: true
         run: node scripts/enrich-current-event-videos.mjs
 
       - name: Audit automated update
@@ -61,6 +64,10 @@ jobs:
 
       - name: Notify IndexNow of fresh sitemap
         if: steps.brain.outputs.changed == 'true' || steps.videos.outputs.changed == 'true'
+        # IndexNow is a best-effort search-engine ping. A 5xx from Bing/Yandex
+        # must not invalidate an otherwise-clean live update — the sitemap is
+        # still available for crawlers via the next polite poll.
+        continue-on-error: true
         run: npm run seo:ping
 
       - name: Create breaking-news email draft
@@ -73,17 +80,30 @@ jobs:
       - name: Commit and push content update
         if: steps.brain.outputs.changed == 'true' || steps.videos.outputs.changed == 'true'
         run: |
+          # The "Audit automated update" step earlier in this workflow already
+          # ran `npm run audit:all` (which includes audit:automated). Re-running
+          # it here would be redundant — the data hasn't changed since.
           git config user.name "Surfaced Bot"
           git config user.email "bot@surfaced.daily"
-          npm run audit:automated
           git add automated-content public/automated-content
           if git diff --staged --quiet; then
             echo "No live content changes to commit"
             exit 0
           fi
           git commit -m "Content Update: live signals $(date -u +%Y-%m-%dT%H:%MZ)"
-          git pull --rebase --autostash origin main
-          git push
+          # Retry push up to 3x — the bot pushes from multiple workflows so
+          # a transient race against a parallel commit shouldn't waste a run.
+          for attempt in 1 2 3; do
+            git pull --rebase --autostash origin main
+            if git push; then
+              echo "Push succeeded on attempt $attempt"
+              exit 0
+            fi
+            echo "Push attempt $attempt failed; retrying in $((attempt * 5))s..."
+            sleep $((attempt * 5))
+          done
+          echo "Push failed after 3 attempts"
+          exit 1
 
   alert-on-failure:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Cross-workflow audit found 6 small but real reliability and efficiency gaps that don't fit a single failure narrative but compound across the automation surface. All 6 are bundled here — each is a YAML-only change, every modified workflow passes `actionlint` with 0 errors, no script or product code touched.

## Findings + fixes

| # | Severity | Workflow | Issue | Fix |
|---|---|---|---|---|
| **F1** | High | trending-live | `npm run seo:ping` (IndexNow) failure could fail the whole pipeline | Add `continue-on-error: true` |
| **F2** | Medium | trending-live | YouTube Data API quota exhaustion / flakes could fail the pipeline | Add `continue-on-error: true` to enrichment step |
| **F3** | Medium | daily-edition + trending-live + social-posts | `git push` had no retry; 3 parallel bots can race and fail an otherwise-clean 30-min run | 3-attempt push retry with rebase between attempts |
| **F4** | Low–Medium | data-backup | Weekly tarball missed `automated-content/*.json` (current-events, trending-live, drafts) | Include in tar |
| **F5** | Low | trending-live | `audit:automated` ran twice in success path (~3–5s wasted per run) | Remove redundant inline call |
| **F6** | Low | social-posts | `setup-node` missing `cache: 'npm'`; ~10s lost per run | Add cache key |

## Why these together

- **F1 + F2**: standardize fail-soft posture for *best-effort* network calls. Now every non-critical external call (IndexNow, YouTube, Buttondown, ASIN upgrade, image fetch, URL spot-check) is uniformly `continue-on-error`. Only the publishing gate itself is fail-closed.
- **F3**: addresses the *only* remaining cross-workflow race. Surfaced has 3 bots pushing from independent workflows; a transient race against a parallel commit currently wastes a 30-min Gemini run.
- **F4**: closes a backup-coverage gap exposed by the trending-live's 8x/day commit cadence.
- **F5 + F6**: pure efficiency wins, ~30–60s of CI time recovered per day at zero risk.

## Forecast (post-merge)

With this bundle, the remaining failure paths are:
1. **Genuine generation collapse** in `daily-edition` (e.g., Gemini returns 0/5 valid items in any category for 5 attempts) → throws + restores backup + opens issue. Correct behavior.
2. **Critical-API outage** (Cloudflare auth / GitHub itself / Anthropic API down) → throws + opens issue. Correct behavior.

All other classes of failure historically observed (saturation, http:// URLs, push races, IndexNow flakes, YouTube quota, audit duplication) now have deterministic fall-throughs that don't fail the workflow.

## Validation

| Command | Result |
|---|---|
| `actionlint .github/workflows/*.yml` | ✅ 0 errors across all modified workflows |
| Python YAML parse | ✅ valid YAML for all 4 files |
| `node scripts/validate-data.js` | ✅ |
| `npm run audit:automated` | ✅ |
| `npm run build` | ✅ 2,793 pages |
| `npm run validate:seo` (strict, postbuild) | ✅ 0 errors / 0 warnings |

## Files changed

- [.github/workflows/daily-edition.yml](.github/workflows/daily-edition.yml) — push retry
- [.github/workflows/trending-live.yml](.github/workflows/trending-live.yml) — `continue-on-error` on YouTube + IndexNow, push retry, removed duplicate audit
- [.github/workflows/social-posts.yml](.github/workflows/social-posts.yml) — `cache: 'npm'`, push retry
- [.github/workflows/data-backup.yml](.github/workflows/data-backup.yml) — `automated-content/*.json` in tar

Net: 4 files, +55 / −8.

## Preserves
- All hardening from `408faf9` (SHA pins, least-privilege permissions, timeouts, alert-on-failure jobs, Slack webhook fail-soft).
- Backup-restore semantics (PR #66), partial-accept floor (PR #70), HTTPS URL gate (PR #74), weather-alert filter (PR #72).
- Source allowlists, current-event validation, AdSense safeguards.

## Test plan

- [x] `actionlint` clean on all modified workflows
- [x] Local validators + build green
- [ ] (Post-merge) Watch next trending-live run for clean log; the audit-step output should appear once instead of twice
- [ ] (Post-merge) Watch the next bot-push race — pushes that previously would have failed should now retry and succeed
- [ ] (Sun 23:00 UTC) Watch the next weekly data-backup; tarball should include `automated-content/*.json`

## Out of scope (intentional)

- **F7 (cosmetic)**: cron schedules drift ~1 hour during DST transitions. Comments say "8 AM ET" but cron is UTC-fixed. Left as a docs-only follow-up; fixing it properly requires either two cron entries per workflow or accepting the EDT/EST asymmetry. Not a correctness bug — just a documentation mismatch.
- **Lighthouse CI on every content commit**: 8 trending-live + 1 daily + 1 social = ~10 build-validation runs/day, ~5 min each = ~50 min/day. Could be optimized by detecting content-only commits, but adds complexity. Defer until it becomes a quota concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)