### PR TITLE
feat(home): diversify trending-live, polish cards, rotate lead event

### DIFF
--- a/scripts/automated-content-brain.mjs
+++ b/scripts/automated-content-brain.mjs
@@ -362,6 +362,43 @@ function cleanForValidation(item) {
   };
 }
 
+function sourceHostKey(item) {
+  try {
+    return new URL(item.sourceUrl).hostname.toLowerCase().replace(/^www\./, "");
+  } catch {
+    return "unknown";
+  }
+}
+
+/**
+ * Apply diversity caps so the homepage Trending Live rail doesn't show six
+ * near-identical NWS Red Flag Warnings on a busy weather day. Items are
+ * already ranked by score (descending); we walk the list and skip anything
+ * that would push a host or type past its cap. Within a cap, the highest-
+ * scoring items still win.
+ */
+function diversifyByHostAndType(rankedItems, { perHostMax = 2, perTypeMax = 3 } = {}) {
+  const hostCounts = new Map();
+  const typeCounts = new Map();
+  const overflow = [];
+  const kept = [];
+  for (const item of rankedItems) {
+    const host = sourceHostKey(item);
+    const hostN = hostCounts.get(host) || 0;
+    const typeN = typeCounts.get(item.type) || 0;
+    if (hostN >= perHostMax || typeN >= perTypeMax) {
+      overflow.push(item);
+      continue;
+    }
+    hostCounts.set(host, hostN + 1);
+    typeCounts.set(item.type, typeN + 1);
+    kept.push(item);
+  }
+  // If the diversity caps left us with too few items, top up from overflow
+  // (preserving rank order) so the rail never goes empty on a saturated day.
+  return { kept, overflow };
+}
+
 async function main() {
   mkdirSync(AUTOMATED_DIR, { recursive: true });
   mkdirSync(PUBLIC_AUTOMATED_DIR, { recursive: true });
@@ -383,7 +420,20 @@ async function main() {
     .filter((item) => item.sourceTrail.length > 0)
     .sort((a, b) => b.score - a.score);
 
-  const items = ranked.filter((item) => item.score >= EDITORIAL_THRESHOLD).slice(0, MAX_ITEMS);
+  const aboveThreshold = ranked.filter((item) => item.score >= EDITORIAL_THRESHOLD);
+  // Diversity pass: cap items per host/type so the homepage rail isn't a
+  // wall of near-identical entries on a busy day (e.g. 6 NWS Red Flag
+  // Warnings). The diversity floor (4) protects against quiet days when
+  // diversity caps would leave the rail too sparse — in that case we top
+  // up from overflow and accept some same-host repetition rather than
+  // showing an under-populated rail.
+  const DIVERSITY_FLOOR = 4;
+  const { kept, overflow } = diversifyByHostAndType(aboveThreshold);
+  const needsTopup = kept.length < DIVERSITY_FLOOR;
+  const items = needsTopup
+    ? [...kept, ...overflow.slice(0, DIVERSITY_FLOOR - kept.length)].slice(0, MAX_ITEMS)
+    : kept.slice(0, MAX_ITEMS);
+  const cappedCount = aboveThreshold.length - items.length;
   const monitoredSignals = ranked.filter((item) => item.score < EDITORIAL_THRESHOLD).slice(0, MAX_MONITORED);
 
   const next = {
@@ -397,6 +447,9 @@ async function main() {
     decisionLog: [
       ...decisionLog,
       `${items.length} signal(s) cleared the editorial threshold.`,
+      cappedCount > 0
+        ? `${cappedCount} near-duplicate signal(s) deferred to monitors via host/type diversity caps.`
+        : `Diversity caps had no effect (no host/type saturation today).`,
       `${monitoredSignals.length} near-threshold signal(s) kept as monitors.`,
     ],
   };

--- a/src/components/home/CurrentEventsEngine.tsx
+++ b/src/components/home/CurrentEventsEngine.tsx
@@ -184,17 +184,81 @@ function buildDailyInsightQuiz(event: CurrentEventItem): DailyInsightQuizData | 
   };
 }
 
-function TrendingLiveCard({ item }: { item: TrendingLiveItem }) {
+/**
+ * Visual styling per signal type. Keeps cards visually distinct so a screen
+ * full of trending items doesn't look like 6 copies of the same NWS warning.
+ */
+const TRENDING_LIVE_TYPE_STYLES: Record<
+  TrendingLiveItem["type"],
+  { label: string; pillClass: string; accentClass: string; icon: string }
+> = {
+  "current-event": {
+    label: "Live brief",
+    pillClass: "border-cyan-300/30 bg-cyan-300/[0.08] text-cyan-200",
+    accentClass: "hover:border-cyan-300/35 hover:shadow-[0_8px_30px_rgba(34,211,238,0.08)]",
+    icon: "📡",
+  },
+  "github-trending": {
+    label: "GitHub",
+    pillClass: "border-violet-300/30 bg-violet-300/[0.08] text-violet-200",
+    accentClass: "hover:border-violet-300/35 hover:shadow-[0_8px_30px_rgba(167,139,250,0.08)]",
+    icon: "✦",
+  },
+  "news-trending": {
+    label: "News",
+    pillClass: "border-amber-300/30 bg-amber-300/[0.08] text-amber-200",
+    accentClass: "hover:border-amber-300/35 hover:shadow-[0_8px_30px_rgba(252,211,77,0.08)]",
+    icon: "❖",
+  },
+};
+
+/** Tier-style coloring for the score badge — gives the eye something to scan. */
+function scoreBadgeClass(score: number): string {
+  if (score >= 95) return "border-amber-300/40 bg-amber-300/[0.12] text-amber-200";
+  if (score >= 88) return "border-emerald-300/35 bg-emerald-300/[0.08] text-emerald-200";
+  return "border-border/70 bg-background/40 text-muted-foreground";
+}
+
+/**
+ * Compact relative-time formatter that's stable at build time.
+ * Returns "Just now", "Nm ago", "Nh ago", or "Nd ago" — nothing fancier
+ * because static-export pages bake in build-time values; "minutes ago"
+ * would already be stale by the time a reader sees it.
+ */
+function formatRelativeAge(detectedAt: string, now: Date): string {
+  const detected = new Date(detectedAt);
+  if (Number.isNaN(detected.getTime())) return "";
+  const diffMs = Math.max(0, now.getTime() - detected.getTime());
+  const minutes = Math.floor(diffMs / 60000);
+  if (minutes < 5) return "Just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+function TrendingLiveCard({ item, now }: { item: TrendingLiveItem; now: Date }) {
   const source = item.sourceTrail[0] ?? { name: item.sourceName, url: item.sourceUrl };
   const href = item.url || item.sourceUrl;
+  const style = TRENDING_LIVE_TYPE_STYLES[item.type] ?? TRENDING_LIVE_TYPE_STYLES["current-event"];
+  const age = formatRelativeAge(item.detectedAt, now);
 
   return (
-    <article className="rounded-xl border border-border bg-surface p-4">
+    <article
+      className={`group relative rounded-xl border border-border bg-surface p-4 transition-all duration-200 ${style.accentClass}`}
+    >
       <div className="flex items-start justify-between gap-3">
-        <span className="rounded-full border border-border/70 bg-background/35 px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.12em] text-muted-foreground">
-          {item.type === "github-trending" ? "GitHub" : item.type === "news-trending" ? "News" : "Live guide"}
+        <span
+          className={`inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.12em] ${style.pillClass}`}
+        >
+          <span aria-hidden="true">{style.icon}</span>
+          {style.label}
         </span>
-        <span className="text-[11px] font-black text-emerald-200">
+        <span
+          className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-black ${scoreBadgeClass(item.score)}`}
+          title={`Editorial score ${item.score}/100`}
+        >
           {item.score}
         </span>
       </div>
@@ -204,7 +268,7 @@ function TrendingLiveCard({ item }: { item: TrendingLiveItem }) {
       <p className="mt-2 text-xs leading-relaxed text-muted line-clamp-3">
         {item.summary}
       </p>
-      <div className="mt-4 flex flex-wrap items-center gap-3">
+      <div className="mt-4 flex flex-wrap items-center gap-x-3 gap-y-1.5">
         <a
           href={href}
           target={href.startsWith("http") ? "_blank" : undefined}
@@ -221,6 +285,14 @@ function TrendingLiveCard({ item }: { item: TrendingLiveItem }) {
         >
           Source: {source.name}
         </a>
+        {age && (
+          <span
+            className="ml-auto text-[10px] font-semibold uppercase tracking-[0.1em] text-muted-foreground/80"
+            title={`Detected ${item.detectedAt}`}
+          >
+            {age}
+          </span>
+        )}
       </div>
     </article>
   );
@@ -229,6 +301,24 @@ function TrendingLiveCard({ item }: { item: TrendingLiveItem }) {
 function TrendingLiveRail({ events }: { events: CurrentEventItem[] }) {
   const items = getTrendingLiveItems(events, 6);
   if (!items.length) return null;
+
+  // Build-time "now" used to format relative ages on the cards. Static export
+  // bakes this in; the page is rebuilt every 3h via the trending-live workflow,
+  // so "Nh ago" stays accurate within that cadence. Client-side mismatch is a
+  // non-issue because the timestamps come from the same JSON the cards read.
+  const generatedAt = getTrendingLiveGeneratedAt();
+  const now = new Date(generatedAt);
+  if (Number.isNaN(now.getTime())) now.setTime(Date.now());
+
+  // Type breakdown helps the rail header advertise diversity at a glance.
+  const typeCounts = items.reduce<Record<string, number>>((acc, item) => {
+    acc[item.type] = (acc[item.type] || 0) + 1;
+    return acc;
+  }, {});
+  const breakdownParts = Object.entries(typeCounts).map(([type, n]) => {
+    const label = TRENDING_LIVE_TYPE_STYLES[type as TrendingLiveItem["type"]]?.label || type;
+    return `${n} ${label.toLowerCase()}`;
+  });
 
   return (
     <div className="mb-5 rounded-xl border border-cyan-300/15 bg-cyan-300/[0.035] p-4 sm:p-5">
@@ -240,17 +330,22 @@ function TrendingLiveRail({ events }: { events: CurrentEventItem[] }) {
           <h3 className="mt-1 text-lg font-black tracking-tight text-foreground">
             Signals with source trails
           </h3>
+          {breakdownParts.length > 0 && (
+            <p className="mt-1 text-[11px] text-muted-foreground">
+              {breakdownParts.join(" · ")}
+            </p>
+          )}
         </div>
         <div className="flex flex-wrap gap-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
           <span className="rounded-full border border-border bg-surface px-3 py-1">
-            Refreshed {formatCurrentEventDate(getTrendingLiveGeneratedAt().slice(0, 10))}
+            Refreshed {formatCurrentEventDate(generatedAt.slice(0, 10))}
           </span>
-          <TrendingLiveAutoRefresh generatedAt={getTrendingLiveGeneratedAt()} />
+          <TrendingLiveAutoRefresh generatedAt={generatedAt} />
         </div>
       </div>
       <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
         {items.map((item) => (
-          <TrendingLiveCard key={item.id} item={item} />
+          <TrendingLiveCard key={item.id} item={item} now={now} />
         ))}
       </div>
     </div>

--- a/src/lib/current-events.ts
+++ b/src/lib/current-events.ts
@@ -108,9 +108,41 @@ export const monitoredCurrentEvents = rankCurrentEvents(
   allCurrentEvents.filter((event) => event.status === "active"),
 );
 
-export const currentEvents = monitoredCurrentEvents.filter(
+const homepageEligible = monitoredCurrentEvents.filter(
   (event) => getCurrentEventDiagnostics(event).homepageEligible,
 );
+
+/**
+ * Day-of-year (UTC) — gives us a deterministic 0..365 bucket that's stable
+ * across multiple builds on the same calendar day but rotates at midnight UTC.
+ * Used to cycle the homepage lead event through the homepage-eligible pool
+ * so readers don't see the same "Today's response guide" hero for two weeks
+ * in a row when several evergreen events are active simultaneously.
+ */
+function dayOfYearUTC(date = new Date()): number {
+  const start = Date.UTC(date.getUTCFullYear(), 0, 0);
+  const ms = Date.UTC(
+    date.getUTCFullYear(),
+    date.getUTCMonth(),
+    date.getUTCDate(),
+  ) - start;
+  return Math.floor(ms / 86_400_000);
+}
+
+/**
+ * Rotate the homepage-eligible events so the lead changes daily. Original
+ * priority order is preserved as the tie-breaker — items further down stay
+ * lower in the rotation. Build-time only; the static export freezes the
+ * order until the next build (daily-edition / trending-live workflows
+ * rebuild within hours of UTC midnight).
+ */
+function rotateForToday<T>(items: T[]): T[] {
+  if (items.length < 2) return items;
+  const offset = dayOfYearUTC() % items.length;
+  return [...items.slice(offset), ...items.slice(0, offset)];
+}
+
+export const currentEvents = rotateForToday(homepageEligible);
 
 export const leadCurrentEvent = currentEvents[0] ?? null;
 


### PR DESCRIPTION
## Summary

Three coordinated changes to the homepage's editorial sections, addressing your screenshot feedback that the Trending Live rail looked bland (six near-identical NWS Red Flag Warning cards, every score 100, every source "National Weather Service") and the "Today's response guide" hero was stuck on the same tick-season story since 2026-04-23.

## What changes

### 1. Diversify trending-live signals — `scripts/automated-content-brain.mjs`

Add per-host (max 2) and per-type (max 3) caps in the editorial-threshold pass. Items still ranked by score; diversity caps just skip near-duplicates further down the list. A diversity floor (4) tops up from overflow on quiet days so the rail is never sparse.

Local before/after on the same signal pool:
| | Before | After |
|---|---|---|
| Items | 8 | 5 |
| Hosts | api.weather.gov (6), cpsc.gov (1), github.com (1) | api.weather.gov (2), cpsc.gov (1), github.com (2) |
| Types | all `current-event` | mixed |
| Deferred | — | 21 (logged in decisionLog) |

### 2. Visual polish on `TrendingLiveCard` — `src/components/home/CurrentEventsEngine.tsx`

- **Type-based accents**: cyan/violet/amber pills with per-type icons + matching hover glow
- **Tier-coloured score badge**: amber 95+, emerald 88–94, neutral below — so the eye can scan strength instead of seeing six identical green "100"s
- **Relative-time chip**: "3h ago", "Just now" — computed from feed's `generatedAt` (build-time stable)
- **Rail subheader**: "3 live brief · 2 github · 1 news" — surfaces diversity at a glance

No CSS file edits. Uses existing Tailwind utilities only.

### 3. Daily rotation of the lead event — `src/lib/current-events.ts`

The "Today's response guide" hero pulled from `currentEvents[0]` hadn't changed since 2026-04-23 because three evergreen events sit at high active strength and array order was static.

Add deterministic `rotateForToday()` that cycles the array by `dayOfYearUTC() % length`. Supporting events at `currentEvents.slice(1, 3)` rotate in lockstep — all three still appear above the fold every day, just in different positions. `/live/<id>` URLs unaffected (each event keeps its own static page).

**Today (May 8, day 128, 3 events)**: lead = "Air Quality Awareness Week" (was "Tick season"). Tomorrow rotates to "Tick season", day after to "Hurricane Preparedness", repeating in 3-day cycles until the curated set changes.

Static export semantics: rotation is computed at build time, frozen until next rebuild. The trending-live workflow rebuilds within 3h of UTC midnight every day, so rotation lag never exceeds one build cycle.

## Why these together

The user's screenshot shows the Trending Live section. Without (1) the cards stay identical regardless of (2)'s styling. Without (2) the diversity from (1) is hidden behind same-color cards. (3) addresses a related-but-separate "the same CDC story has been there for two weeks" concern in the same scoped editorial-section feedback.

## Validation

| Command | Result |
|---|---|
| `node --check` (modified scripts) | ✅ |
| `node scripts/validate-data.js` | ✅ |
| `npm run audit:automated` | ✅ |
| `npm run build` | ✅ 2,793 pages |
| `npm run validate:seo` (strict, postbuild) | ✅ 0 errors / 0 warnings |
| Visual verification of built `out/index.html` | ✅ lead = "Air Quality Awareness Week"; type pills `Live brief` / `GitHub` / `News` present; breakdown `3 live brief · 2 github` rendered |
| Brain dry-run (real GitHub API, fail-soft for absent gnews/newsapi keys) | ✅ 5 items, mix of types/hosts; 21 near-duplicates correctly deferred to monitors |

## Files changed

- [scripts/automated-content-brain.mjs](scripts/automated-content-brain.mjs) — +52 / −3 (diversity caps + decisionLog)
- [src/components/home/CurrentEventsEngine.tsx](src/components/home/CurrentEventsEngine.tsx) — +103 / −10 (TrendingLiveCard rewrite, rail subheader)
- [src/lib/current-events.ts](src/lib/current-events.ts) — +33 / −5 (rotation helper)

`automated-content/trending-live.json` is intentionally **not** committed — the trending-live workflow will regenerate it within 3 hours with the new diversity logic. Avoids snapshotting today's specific weather alerts in git.

## Preserves

- Fail-closed publishing gate (≥ EDITORIAL_THRESHOLD threshold unchanged)
- Source allowlists, current-event validation, automated-content schema
- All hardening from PRs #66, #70, #72, #74, #75
- `/live/<id>` static pages for every active event

## Test plan

- [x] Build clean
- [x] Lead event verified to be different from yesterday's
- [x] Type breakdown rendered in HTML
- [ ] (Post-merge) Watch next trending-live workflow run (~3h cadence) — should produce a more varied items list and log "N near-duplicate signal(s) deferred"
- [ ] (Post-merge) Visual sanity-check on `surfaced-x.pages.dev` after Cloudflare deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)