### PR TITLE
Full 3D world: persistent global scene + cursor companion + Roulette

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -391,6 +391,138 @@ h3 {
 }
 
 /* ============================================
+   GLOBAL 3D WORLD — transparent body surfaces
+   The fixed <GlobalWorld /> canvas renders below z=0. To let it show through
+   we override the dark page background with semi-transparent layers and add
+   subtle scrims so text stays legible at all scroll positions.
+   ============================================ */
+body.has-3d-world {
+  background: transparent !important;
+}
+
+[data-theme="light"] body.has-3d-world {
+  background: transparent !important;
+}
+
+/* Sections that used solid backgrounds become floating glass over the world */
+body.has-3d-world section.bg-background,
+body.has-3d-world .bg-background {
+  background: transparent !important;
+}
+
+/* Backdrop scrim for legibility — pairs with the GlobalWorld's own scrim */
+.world-scrim {
+  background: linear-gradient(180deg, rgba(8,8,12,0.55) 0%, rgba(8,8,12,0.35) 30%, rgba(8,8,12,0.65) 100%);
+}
+[data-theme="light"] .world-scrim {
+  background: linear-gradient(180deg, rgba(250,250,247,0.65) 0%, rgba(250,250,247,0.45) 30%, rgba(250,250,247,0.75) 100%);
+}
+
+/* Floating glass — replaces opaque .bg-card on most cards so the world peeks through */
+.floating-glass {
+  background: rgba(15, 15, 20, 0.62);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(18px) saturate(1.2);
+  -webkit-backdrop-filter: blur(18px) saturate(1.2);
+  transition: background-color 0.3s ease, border-color 0.3s ease, transform 0.3s ease;
+}
+.floating-glass:hover {
+  background: rgba(15, 15, 20, 0.78);
+  border-color: rgba(255, 255, 255, 0.15);
+  transform: translateY(-2px);
+}
+[data-theme="light"] .floating-glass {
+  background: rgba(255, 255, 255, 0.78);
+  border-color: rgba(0, 0, 0, 0.06);
+  color: #1a1a1f;
+  backdrop-filter: blur(18px) saturate(1.4);
+  -webkit-backdrop-filter: blur(18px) saturate(1.4);
+}
+[data-theme="light"] .floating-glass:hover {
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.12);
+}
+
+/* ============================================
+   CURSOR COMPANION — fuse.kiwi-style follower
+   ============================================ */
+.companion-orb,
+.companion-trail {
+  position: fixed;
+  top: 0;
+  left: 0;
+  pointer-events: none;
+  z-index: 80;
+  border-radius: 9999px;
+  will-change: transform;
+  transition: width 0.25s ease, height 0.25s ease, background-color 0.25s ease, border-color 0.25s ease;
+}
+.companion-orb {
+  width: 28px;
+  height: 28px;
+  background: rgba(255, 255, 255, 0.92);
+  mix-blend-mode: difference;
+}
+.companion-trail {
+  width: 56px;
+  height: 56px;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  mix-blend-mode: difference;
+}
+.companion-orb.companion-hover {
+  width: 48px;
+  height: 48px;
+  background: rgba(168, 85, 247, 0.9);
+  transform: translate3d(var(--x, 0), var(--y, 0), 0) scale(1.15);
+}
+.companion-orb.companion-press {
+  background: rgba(34, 211, 238, 0.9);
+}
+
+/* Hide the OS cursor on the magic chrome — kept the default cursor everywhere
+   else so accessibility remains intact. */
+@media (pointer: fine) {
+  body.has-3d-world {
+    cursor: auto; /* keep system cursor; the orb is a companion, not a replacement */
+  }
+}
+
+/* ============================================
+   FLOATING ITEM CARD — for archives + listings.
+   Slightly less opaque than .alcove-card so the world is more visible.
+   ============================================ */
+.floating-item {
+  background: rgba(15, 15, 20, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(14px) saturate(1.2);
+  -webkit-backdrop-filter: blur(14px) saturate(1.2);
+}
+[data-theme="light"] .floating-item {
+  background: rgba(255, 255, 255, 0.78);
+  border-color: rgba(0, 0, 0, 0.06);
+  color: #1a1a1f;
+}
+
+/* Depth mode — triggered by long-press, gives the page a temporary cinema feel */
+body.depth-mode {
+  perspective: 1400px;
+  transition: filter 0.4s ease;
+  filter: saturate(1.18) brightness(1.06);
+}
+body.depth-mode main {
+  transform: scale(0.985);
+  transition: transform 0.45s cubic-bezier(0.32, 0.72, 0, 1);
+}
+body.depth-mode .floating-glass,
+body.depth-mode .alcove-card,
+body.depth-mode .floating-item {
+  transform: translateZ(0) scale(1.012);
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.4);
+  transition: transform 0.45s cubic-bezier(0.32, 0.72, 0, 1), box-shadow 0.45s ease;
+}
+
+/* ============================================
    Shadow System
    ============================================ */
 .premium-shadow {

--- a/src/app/item/[slug]/page.tsx
+++ b/src/app/item/[slug]/page.tsx
@@ -51,8 +51,10 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import { alcoveFromCategory } from "@/lib/alcoves";
-import { AlcoveBackdrop } from "@/components/3d/AlcoveBackdrop";
+import { ItemWorldSeeder } from "@/components/3d/ItemWorldSeeder";
 import { BYLINE } from "@/lib/masthead";
+// AlcoveFromCategory still used in jsonld + scene labelling
+void alcoveFromCategory;
 
 /* ---- Cross-category recommendations ---- */
 function getCrossCategoryItems(item: AnyItem, count = 4): AnyItem[] {
@@ -316,12 +318,16 @@ export default async function ItemPage({ params }: Props) {
     <>
       <ScrollProgress />
       <BackToTop />
+      <ItemWorldSeeder slug={slug} category={category} />
       <script type="application/ld+json" dangerouslySetInnerHTML={ldScript(itemLd)} />
       <script type="application/ld+json" dangerouslySetInnerHTML={ldScript(crumbsLd)} />
 
-      {/* ── Hero image with category alcove backdrop ─────── */}
-      <div className="w-full overflow-hidden border-b border-border/30 relative">
-        <AlcoveBackdrop alcove={alcoveFromCategory(category)} trackScroll intimate />
+      {/* ── Hero image — sits on the global 3D world ──── */}
+      <div
+        data-world-scene={`item-${item.type}`}
+        className="w-full overflow-hidden border-b border-white/[0.06] relative"
+      >
+        <div className="absolute inset-0 world-scrim pointer-events-none" aria-hidden="true" />
         <div className="relative z-10">
           {item.type === "hidden-gem" && (item as HiddenGem).screenshotUrl ? (
             <ScreenshotImage src={(item as HiddenGem).screenshotUrl!} alt={title} />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,10 @@ import { ServiceWorkerRegistration } from "@/components/ServiceWorkerRegistratio
 import { PrefetchLinks } from "@/components/ui/PrefetchLinks";
 import { AdSenseLoader } from "@/components/AdSenseLoader";
 import { PageMorph } from "@/components/ui/PageMorph";
+import { GlobalWorld } from "@/components/3d/GlobalWorld";
+import { CursorCompanion } from "@/components/3d/CursorCompanion";
+import { AmbientSoundscape } from "@/components/3d/AmbientSoundscape";
+import { HiddenInteractions } from "@/components/3d/HiddenInteractions";
 import { SITE_URL, SITE_NAME, TWITTER_HANDLE, DEFAULT_OG_IMAGE } from "@/lib/seo";
 import { organizationLd, websiteLd, ldScript } from "@/lib/jsonld";
 import "./globals.css";
@@ -104,10 +108,12 @@ export default function RootLayout({
         <link rel="dns-prefetch" href="https://pagead2.googlesyndication.com" />
         <link rel="dns-prefetch" href="https://googleads.g.doubleclick.net" />
       </head>
-      <body className="noise">
+      <body className="noise has-3d-world">
         <script type="application/ld+json" dangerouslySetInnerHTML={ldScript(websiteLd())} />
         <script type="application/ld+json" dangerouslySetInnerHTML={ldScript(organizationLd())} />
         <AdSenseLoader />
+        {/* GlobalWorld lives behind everything — persistent across navigation */}
+        <GlobalWorld />
         <a
           href="#main-content"
           className="sr-only focus:not-sr-only focus:absolute focus:z-[200] focus:top-4 focus:left-4 focus:px-4 focus:py-2 focus:bg-white focus:text-black focus:rounded-lg focus:font-semibold focus:text-sm focus:shadow-lg"
@@ -116,12 +122,15 @@ export default function RootLayout({
         </a>
         <SearchModal />
         <Navbar />
-        <main id="main-content" className="min-h-screen pt-16">
+        <main id="main-content" className="min-h-screen pt-16 relative">
           <PageMorph>{children}</PageMorph>
         </main>
         <Footer />
         <ServiceWorkerRegistration />
         <PrefetchLinks />
+        <CursorCompanion />
+        <AmbientSoundscape />
+        <HiddenInteractions />
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,15 +1,18 @@
 import Link from "next/link";
 import { Suspense } from "react";
-import { hiddenGems, dailyTools, getItemExcerpt, getItemCategory, getItemTitle, type AnyItem } from "@/lib/data";
+import {
+  hiddenGems,
+  dailyTools,
+  getItemExcerpt,
+  getItemCategory,
+  getItemTitle,
+  type AnyItem,
+} from "@/lib/data";
 import { itemListLd, ldScript } from "@/lib/jsonld";
 import { CategoryBadge } from "@/components/ui/CategoryBadge";
 import { ScrollReveal } from "@/components/ui/ScrollReveal";
 import { NewsletterSection } from "@/components/home/NewsletterSection";
-import { allAlcoves, alcoveByKind, alcoveFromCategory, type Alcove } from "@/lib/alcoves";
-import { AlcoveBackdrop } from "@/components/3d/AlcoveBackdrop";
-import { HeroAlcoveRotator } from "@/components/3d/HeroAlcoveRotator";
-import { HiddenInteractions } from "@/components/3d/HiddenInteractions";
-import { SoundscapeToggle } from "@/components/3d/SoundscapeToggle";
+import { alcoveByKind, alcoveFromCategory, type Alcove } from "@/lib/alcoves";
 import { ItemImage } from "@/components/ui/ItemImage";
 import { HomeStreakStatus, SearchSurfacedButton } from "@/components/home/HomeHeroActions";
 import { LiveNowTicker } from "@/components/home/LiveNowTicker";
@@ -35,7 +38,6 @@ export default function HomePage() {
   const newestTools = rank(dailyTools);
   const newestGems = rank(hiddenGems);
 
-  // Lead story = newest badged item, else newest tool
   const allKept: AnyItem[] = [...newestTools, ...newestGems];
   const leadStory =
     allKept.find((i) => !!(i as { badge?: string }).badge) ?? newestTools[0] ?? newestGems[0];
@@ -44,7 +46,7 @@ export default function HomePage() {
     .filter((i) => i.slug !== leadStory?.slug)
     .slice(0, 5);
 
-  // Alcove rotation — 6 worlds, ordered by how heavily we cover that category
+  // Six "alcove" sections, each a deeper layer of the world
   const alcoves: Alcove[] = [
     alcoveByKind("productivity"),
     alcoveByKind("developer"),
@@ -54,7 +56,6 @@ export default function HomePage() {
     alcoveByKind("finance"),
   ];
 
-  // Featured per-alcove: 4 items from that category
   const featuredPerAlcove = alcoves.map((alc) => {
     const matchingTools = newestTools.filter((t) => alcoveFromCategory(getItemCategory(t)).kind === alc.kind);
     const matchingGems = newestGems.filter((g) => alcoveFromCategory(getItemCategory(g)).kind === alc.kind);
@@ -62,20 +63,22 @@ export default function HomePage() {
   });
 
   const ld = itemListLd(
-    [leadStory, ...supporting].filter(Boolean).map((p) => ({ url: `/item/${p.slug}`, name: getTitle(p) })),
+    [leadStory, ...supporting].filter(Boolean).map((p) => ({ url: `/item/${p.slug}`, name: getItemTitle(p) })),
     "Today's Edition"
   );
 
   return (
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={ldScript(ld)} />
-      <HiddenInteractions />
 
       {/* ============================================
-          HERO — fixed 3D backdrop, rotating alcoves
+          HERO — full-bleed over the GlobalWorld backdrop
           ============================================ */}
-      <section className="relative min-h-screen -mt-16 pt-16 flex items-center overflow-hidden">
-        <HeroAlcoveRotator alcoves={alcoves} intervalMs={6000} fixed />
+      <section
+        data-world-scene="hero"
+        className="relative min-h-screen -mt-16 pt-16 flex items-center overflow-hidden"
+      >
+        <div className="absolute inset-0 world-scrim pointer-events-none" aria-hidden="true" />
 
         <div className="relative z-10 max-w-5xl mx-auto px-4 sm:px-6 py-24 sm:py-32 text-center">
           <div className="flex flex-wrap items-center justify-center gap-2 mb-6">
@@ -86,7 +89,7 @@ export default function HomePage() {
               </span>
               Today&rsquo;s Edition
             </span>
-            <span className="text-xs text-white/80">{editionDate}</span>
+            <span className="text-xs text-white/85">{editionDate}</span>
             <HomeStreakStatus />
           </div>
 
@@ -96,7 +99,7 @@ export default function HomePage() {
               your attention.
             </span>
           </h1>
-          <p className="text-base sm:text-xl text-white/85 max-w-2xl mx-auto leading-relaxed">
+          <p className="text-base sm:text-xl text-white/90 max-w-2xl mx-auto leading-relaxed">
             Surfaced is a hand-edited daily on the most useful tools, hidden web apps, and quiet
             corners of the internet. One editor. No SEO slop. Real opinions on what to use.
           </p>
@@ -104,6 +107,7 @@ export default function HomePage() {
           <div className="mt-9 flex flex-col sm:flex-row items-center justify-center gap-3">
             <Link
               href="#today"
+              data-cursor="hover"
               className="w-full sm:w-auto inline-flex items-center justify-center gap-2 px-7 py-3.5 rounded-xl bg-white text-black text-sm font-semibold hover:bg-white/90 transition-all shadow-[0_10px_40px_rgba(0,0,0,0.5)] active:scale-[0.98]"
             >
               Read today&rsquo;s edition
@@ -114,27 +118,34 @@ export default function HomePage() {
             <SearchSurfacedButton />
           </div>
 
-          <p className="mt-10 text-[11px] uppercase tracking-[0.25em] text-white/55">
-            {hiddenGems.length + dailyTools.length} curated • {alcoves.length} alcoves • Updated daily
-          </p>
-
-          <div className="mt-8 flex justify-center">
+          <div className="mt-10 flex flex-col items-center gap-5">
+            <p className="text-[11px] uppercase tracking-[0.25em] text-white/65">
+              {hiddenGems.length + dailyTools.length} curated · {alcoves.length} alcoves · Updated daily
+            </p>
             <LiveNowTicker
               items={allKept.slice(0, 30).map((i) => ({
                 slug: i.slug,
-                title: getTitle(i),
+                title: getItemTitle(i),
                 category: getItemCategory(i),
                 action: "open",
               }))}
             />
+            <Link
+              href="/roulette"
+              data-cursor="hover"
+              className="inline-flex items-center gap-2 text-[11px] uppercase tracking-[0.22em] text-white/75 hover:text-white transition-colors group"
+            >
+              <span className="block w-6 h-px bg-white/40 group-hover:bg-white transition-colors" />
+              Try the Tool Roulette
+              <span className="block w-6 h-px bg-white/40 group-hover:bg-white transition-colors" />
+            </Link>
           </div>
         </div>
 
-        {/* Scroll hint */}
-        <div className="absolute bottom-6 left-1/2 -translate-x-1/2 z-10 text-white/60">
-          <div className="flex flex-col items-center gap-1.5 text-[10px] uppercase tracking-[0.2em]">
-            Scroll
-            <span className="block w-px h-8 bg-gradient-to-b from-white/60 to-transparent animate-pulse" />
+        <div className="absolute bottom-6 left-1/2 -translate-x-1/2 z-10 text-white/65">
+          <div className="flex flex-col items-center gap-1.5 text-[10px] uppercase tracking-[0.22em]">
+            Scroll into the world
+            <span className="block w-px h-10 bg-gradient-to-b from-white/70 to-transparent animate-pulse" />
           </div>
         </div>
       </section>
@@ -143,36 +154,40 @@ export default function HomePage() {
           TODAY'S EDITION — editorial cover
           ============================================ */}
       {leadStory && (
-        <section id="today" className="relative py-20 sm:py-28 px-4 sm:px-6 scroll-mt-20 bg-background">
-          <div className="max-w-[88rem] mx-auto">
+        <section
+          id="today"
+          data-world-scene="today"
+          className="relative py-20 sm:py-28 px-4 sm:px-6 scroll-mt-20"
+        >
+          <div className="absolute inset-0 world-scrim pointer-events-none" aria-hidden="true" />
+          <div className="relative max-w-[88rem] mx-auto">
             <header className="mb-10 flex flex-col sm:flex-row sm:items-end justify-between gap-6">
               <div>
-                <p className="text-xs uppercase tracking-[0.22em] text-accent font-semibold mb-3">
+                <p className="text-xs uppercase tracking-[0.22em] text-white/75 font-semibold mb-3">
                   Today&rsquo;s Edition · {editionDate}
                 </p>
-                <h2 className="text-3xl sm:text-5xl font-bold tracking-tight">
+                <h2 className="text-3xl sm:text-5xl font-bold tracking-tight text-white">
                   What earned a slot today
                 </h2>
-                <p className="mt-3 text-muted-foreground max-w-2xl">
+                <p className="mt-3 text-white/80 max-w-2xl">
                   One lead pick, five worth your time. Each entry hand-tested, with the official site
                   and a one-line take from {BYLINE.name}.
                 </p>
               </div>
               <Link
                 href="/tools"
-                className="inline-flex items-center gap-1.5 px-4 py-2 rounded-full text-sm font-medium border border-border hover:border-accent/40 hover:text-accent transition-colors self-start sm:self-end"
+                data-cursor="hover"
+                className="inline-flex items-center gap-1.5 px-4 py-2 rounded-full text-sm font-medium border border-white/20 text-white/85 hover:border-white/40 hover:text-white transition-colors self-start sm:self-end backdrop-blur-md bg-white/5"
               >
                 Browse all tools →
               </Link>
             </header>
 
             <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-              {/* Lead story */}
               <ScrollReveal className="lg:col-span-2">
                 <LeadCard item={leadStory} />
               </ScrollReveal>
 
-              {/* Supporting picks */}
               <div className="flex flex-col gap-4">
                 {supporting.slice(0, 3).map((item, idx) => (
                   <ScrollReveal key={item.slug} delay={idx * 80}>
@@ -196,7 +211,7 @@ export default function HomePage() {
       )}
 
       {/* ============================================
-          ALCOVE TOUR — 6 worlds, each with its own scene
+          ALCOVE TOUR — 6 worlds, scroll-driven
           ============================================ */}
       <section className="relative">
         {featuredPerAlcove.map(({ alcove, items }, idx) => (
@@ -205,20 +220,24 @@ export default function HomePage() {
       </section>
 
       {/* ============================================
-          WORKFLOWS — novel feature preview
+          WORKFLOWS preview
           ============================================ */}
-      <section className="relative py-24 sm:py-32 px-4 sm:px-6 bg-background border-t border-border/40">
-        <div className="max-w-5xl mx-auto text-center">
-          <p className="text-xs uppercase tracking-[0.22em] text-accent font-semibold mb-4">
+      <section
+        data-world-scene="workflows"
+        className="relative py-24 sm:py-32 px-4 sm:px-6 border-t border-white/[0.05]"
+      >
+        <div className="absolute inset-0 world-scrim pointer-events-none" aria-hidden="true" />
+        <div className="relative max-w-5xl mx-auto text-center">
+          <p className="text-xs uppercase tracking-[0.22em] text-white/75 font-semibold mb-4">
             New on Surfaced
           </p>
-          <h2 className="text-3xl sm:text-5xl font-bold tracking-tight">
+          <h2 className="text-3xl sm:text-5xl font-bold tracking-tight text-white">
             Tell us your goal.<br className="hidden sm:block" />
-            <span className="bg-gradient-to-r from-violet-400 via-cyan-300 to-amber-300 bg-clip-text text-transparent">
+            <span className="bg-gradient-to-r from-violet-300 via-cyan-200 to-amber-200 bg-clip-text text-transparent">
               We&rsquo;ll stitch the toolchain.
             </span>
           </h2>
-          <p className="mt-5 text-muted-foreground text-lg max-w-2xl mx-auto leading-relaxed">
+          <p className="mt-5 text-white/85 text-lg max-w-2xl mx-auto leading-relaxed">
             Workflows pair real tools into recipes — &ldquo;write a newsletter,&rdquo; &ldquo;design a logo,&rdquo;
             &ldquo;analyze a CSV.&rdquo; Pick one and get three or four apps that actually work together.
           </p>
@@ -233,7 +252,8 @@ export default function HomePage() {
               <Link
                 key={w.goal}
                 href={`/workflows#${encodeURIComponent(w.goal.toLowerCase().replace(/\s+/g, "-"))}`}
-                className="group inline-flex items-center gap-2 px-5 py-3 rounded-full border border-border hover:border-accent/40 bg-surface hover:bg-surface-elevated transition-all text-sm font-medium"
+                data-cursor="hover"
+                className="floating-glass group inline-flex items-center gap-2 px-5 py-3 rounded-full text-sm font-medium"
               >
                 <span className="text-accent">{w.icon}</span>
                 {w.goal}
@@ -244,6 +264,7 @@ export default function HomePage() {
           <div className="mt-10">
             <Link
               href="/workflows"
+              data-cursor="hover"
               className="inline-flex items-center gap-2 px-7 py-3.5 rounded-xl bg-accent text-white text-sm font-semibold hover:bg-accent-hover transition-all"
             >
               Explore all workflows →
@@ -255,8 +276,9 @@ export default function HomePage() {
       {/* ============================================
           BYLINE — E-E-A-T trust signal
           ============================================ */}
-      <section className="py-16 px-4 sm:px-6 border-t border-border/40 bg-surface/40">
-        <div className="max-w-3xl mx-auto flex flex-col sm:flex-row items-center gap-6">
+      <section className="relative py-16 px-4 sm:px-6 border-t border-white/[0.05]">
+        <div className="absolute inset-0 world-scrim pointer-events-none" aria-hidden="true" />
+        <div className="relative max-w-3xl mx-auto flex flex-col sm:flex-row items-center gap-6 floating-glass rounded-2xl p-8">
           <div className="w-20 h-20 rounded-full bg-gradient-to-br from-accent to-cyan flex items-center justify-center text-white text-2xl font-bold flex-shrink-0">
             {BYLINE.initials}
           </div>
@@ -265,33 +287,21 @@ export default function HomePage() {
               Edited by
             </p>
             <p className="text-xl font-bold">{BYLINE.name}</p>
-            <p className="text-sm text-muted-foreground mt-1 leading-relaxed">{BYLINE.bio}</p>
+            <p className="text-sm opacity-80 mt-1 leading-relaxed">{BYLINE.bio}</p>
             <div className="mt-3 flex gap-3 text-xs">
-              <Link href="/about" className="text-accent hover:underline">About</Link>
-              <Link href="/editorial-standards" className="text-accent hover:underline">Editorial standards</Link>
-              <Link href="/contact" className="text-accent hover:underline">Contact</Link>
+              <Link href="/about" className="text-accent hover:underline" data-cursor="hover">About</Link>
+              <Link href="/editorial-standards" className="text-accent hover:underline" data-cursor="hover">Editorial standards</Link>
+              <Link href="/contact" className="text-accent hover:underline" data-cursor="hover">Contact</Link>
             </div>
           </div>
         </div>
       </section>
 
-      {/* ============================================
-          NEWSLETTER
-          ============================================ */}
       <Suspense fallback={null}>
         <NewsletterSection />
       </Suspense>
-
-      <SoundscapeToggle />
     </>
   );
-}
-
-function getTitle(item: AnyItem | undefined): string {
-  if (!item) return "";
-  // Delegate to the smart helper — it falls back to seoTitle when toolName
-  // is slug-shaped (the bulk-generator wrote slugs into toolName for ~30 items).
-  return getItemTitle(item);
 }
 
 function getOutbound(item: AnyItem): string | null {
@@ -312,13 +322,13 @@ function getHost(url: string | null | undefined): string | null {
 /* ──────────────────────────────────────────────────────────── */
 
 function LeadCard({ item }: { item: AnyItem }) {
-  const title = getTitle(item);
+  const title = getItemTitle(item);
   const outbound = getOutbound(item);
   const host = getHost(outbound);
   const alcove = alcoveFromCategory(getItemCategory(item));
 
   return (
-    <article className="group relative overflow-hidden rounded-3xl border border-border/60 bg-card h-full">
+    <article className="floating-glass group relative overflow-hidden rounded-3xl h-full">
       <div className="relative aspect-[16/10] overflow-hidden">
         <ItemImage
           slug={item.slug}
@@ -341,7 +351,7 @@ function LeadCard({ item }: { item: AnyItem }) {
       </div>
       <div className="absolute inset-x-0 bottom-0 p-6 sm:p-8">
         <CategoryBadge label={getItemCategory(item) || "Tool"} color="amber" className="mb-3" />
-        <Link href={`/item/${item.slug}`} className="block group/title">
+        <Link href={`/item/${item.slug}`} data-cursor="hover" className="block group/title">
           <h3 className="text-2xl sm:text-3xl font-bold text-white leading-tight tracking-tight group-hover/title:text-amber-200 transition-colors">
             {title}
           </h3>
@@ -352,6 +362,7 @@ function LeadCard({ item }: { item: AnyItem }) {
         <div className="mt-5 flex flex-wrap items-center gap-3">
           <Link
             href={`/item/${item.slug}`}
+            data-cursor="hover"
             className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-white text-black text-sm font-semibold hover:bg-white/90 transition-colors"
           >
             Read the take
@@ -362,6 +373,7 @@ function LeadCard({ item }: { item: AnyItem }) {
               target="_blank"
               rel="noopener noreferrer"
               data-outbound="true"
+              data-cursor="hover"
               className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-white/10 backdrop-blur-md text-white text-sm font-medium border border-white/20 hover:bg-white/20 transition-colors"
             >
               Visit {host} ↗
@@ -374,7 +386,7 @@ function LeadCard({ item }: { item: AnyItem }) {
 }
 
 function SupportingCard({ item, compact = false }: { item: AnyItem; compact?: boolean }) {
-  const title = getTitle(item);
+  const title = getItemTitle(item);
   const outbound = getOutbound(item);
   const host = getHost(outbound);
   const alcove = alcoveFromCategory(getItemCategory(item));
@@ -382,7 +394,8 @@ function SupportingCard({ item, compact = false }: { item: AnyItem; compact?: bo
   return (
     <Link
       href={`/item/${item.slug}`}
-      className="group block relative overflow-hidden rounded-2xl border border-border/60 bg-card hover:border-accent/40 transition-all"
+      data-cursor="hover"
+      className="floating-glass group block relative overflow-hidden rounded-2xl"
     >
       <div className={`flex ${compact ? "flex-row" : "flex-col"}`}>
         <div className={`relative overflow-hidden ${compact ? "w-32 flex-shrink-0" : "w-full aspect-[16/9]"}`}>
@@ -404,12 +417,12 @@ function SupportingCard({ item, compact = false }: { item: AnyItem; compact?: bo
             {title}
           </h3>
           {!compact && (
-            <p className="mt-2 text-xs text-muted-foreground leading-relaxed line-clamp-2">
+            <p className="mt-2 text-xs opacity-75 leading-relaxed line-clamp-2">
               {getItemExcerpt(item, 120)}
             </p>
           )}
           {host && (
-            <p className="mt-auto pt-2 text-[10px] uppercase tracking-wider text-muted-foreground">
+            <p className="mt-auto pt-2 text-[10px] uppercase tracking-wider opacity-60">
               {host}
             </p>
           )}
@@ -425,8 +438,19 @@ function AlcoveSection({ alcove, items, index }: { alcove: Alcove; items: AnyIte
   if (items.length === 0) return null;
   const flip = index % 2 === 1;
   return (
-    <section className="relative min-h-[80vh] flex items-center overflow-hidden border-t border-white/[0.04]">
-      <AlcoveBackdrop alcove={alcove} trackScroll />
+    <section
+      data-world-scene={`alcove-${alcove.kind}`}
+      className="relative min-h-[80vh] flex items-center overflow-hidden border-t border-white/[0.04]"
+    >
+      {/* World scrim adapts to global world rather than having its own canvas */}
+      <div className="absolute inset-0 world-scrim pointer-events-none" aria-hidden="true" />
+      <div
+        className="absolute inset-0 pointer-events-none opacity-50"
+        style={{
+          background: `radial-gradient(circle at ${flip ? "75%" : "25%"} 50%, ${alcove.palette[1]}25, transparent 60%)`,
+        }}
+        aria-hidden="true"
+      />
       <div className="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 py-20 sm:py-28 w-full">
         <div className={`flex flex-col ${flip ? "lg:flex-row-reverse" : "lg:flex-row"} gap-10 lg:gap-16 items-start`}>
           <div className="lg:w-1/3 lg:sticky lg:top-28">
@@ -436,11 +460,12 @@ function AlcoveSection({ alcove, items, index }: { alcove: Alcove; items: AnyIte
             <h2 className="text-4xl sm:text-6xl font-bold text-white leading-[0.95] tracking-tight">
               {alcove.label}
             </h2>
-            <p className="mt-5 text-white/80 text-lg leading-relaxed max-w-md">
+            <p className="mt-5 text-white/85 text-lg leading-relaxed max-w-md">
               {alcove.tagline}
             </p>
             <Link
               href={`/tools?category=${encodeURIComponent(alcove.label)}`}
+              data-cursor="hover"
               className="mt-7 inline-flex items-center gap-2 px-5 py-2.5 rounded-full bg-white/10 backdrop-blur-md border border-white/20 text-white text-sm font-medium hover:bg-white/20 transition-colors"
             >
               See all {alcove.label} tools →
@@ -461,10 +486,11 @@ function AlcoveSection({ alcove, items, index }: { alcove: Alcove; items: AnyIte
 }
 
 function AlcoveItemCard({ item }: { item: AnyItem }) {
-  const title = getTitle(item);
+  const title = getItemTitle(item);
   return (
     <Link
       href={`/item/${item.slug}`}
+      data-cursor="hover"
       className="alcove-card group block relative overflow-hidden rounded-2xl transition-all p-5 h-full"
     >
       <div className="flex items-start gap-3 mb-3">
@@ -482,6 +508,3 @@ function AlcoveItemCard({ item }: { item: AnyItem }) {
     </Link>
   );
 }
-
-// Keep allAlcoves available for future routes
-void allAlcoves;

--- a/src/app/roulette/page.tsx
+++ b/src/app/roulette/page.tsx
@@ -1,0 +1,52 @@
+import type { Metadata } from "next";
+import { buildMetadata } from "@/lib/seo";
+import { hiddenGems, dailyTools, getItemTitle, getItemCategory, getItemExcerpt } from "@/lib/data";
+import { RouletteClient } from "@/components/roulette/RouletteClient";
+
+export const metadata: Metadata = buildMetadata({
+  title: "Tool Roulette",
+  description:
+    "Spin to discover a random hand-picked tool from Surfaced. Pair it with a real use case, save your favourites, never look at another endless list again.",
+  path: "/roulette",
+});
+
+// Strip data down to client-safe shape (no full bodies)
+const pool = [...hiddenGems, ...dailyTools].map((i) => ({
+  slug: i.slug,
+  title: getItemTitle(i),
+  category: getItemCategory(i),
+  excerpt: getItemExcerpt(i, 140),
+  outbound:
+    (i.type === "hidden-gem" ? i.websiteLink : i.type === "tool" ? i.websiteLink : null) || null,
+}));
+
+export default function RoulettePage() {
+  return (
+    <article data-world-scene="roulette" className="relative min-h-screen">
+      <div className="absolute inset-0 world-scrim pointer-events-none" aria-hidden="true" />
+      <div className="relative max-w-5xl mx-auto px-4 sm:px-6 py-24 sm:py-32">
+        <header className="text-center mb-12">
+          <p className="text-xs uppercase tracking-[0.25em] text-white/70 font-semibold mb-4">
+            Surfaced · Tool Roulette
+          </p>
+          <h1 className="text-5xl sm:text-7xl font-bold tracking-tight text-white leading-[0.95]">
+            Pick a goal.
+            <span className="block bg-gradient-to-r from-violet-300 via-cyan-200 to-amber-200 bg-clip-text text-transparent">
+              Spin the world.
+            </span>
+          </h1>
+          <p className="mt-6 text-white/85 text-lg max-w-2xl mx-auto leading-relaxed">
+            Hit spin and Surfaced will pull a random tool from {pool.length} hand-tested entries —
+            paired with a use case you can act on right now. Lock in favourites, skip duds.
+          </p>
+        </header>
+
+        <RouletteClient pool={pool} />
+
+        <footer className="mt-16 text-center text-xs uppercase tracking-[0.2em] text-white/55">
+          History stored locally — never sent anywhere.
+        </footer>
+      </div>
+    </article>
+  );
+}

--- a/src/components/3d/AmbientSoundscape.tsx
+++ b/src/components/3d/AmbientSoundscape.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { usePathname } from "next/navigation";
+import { deriveWorldSeed } from "@/lib/world-seed";
+
+/**
+ * Ambient soundscape — pure Web Audio synthesis (no audio files shipped).
+ * Each route gets a unique chord built from the alcove palette's frequency
+ * mapping. Crossfades smoothly when the user navigates.
+ *
+ * Strictly opt-in: silent until the user clicks the speaker toggle. Once
+ * enabled, the preference persists in localStorage and follows the user
+ * across routes. Toggle is always visible bottom-right.
+ *
+ * Accessibility: respects prefers-reduced-motion as a hint (still allows
+ * opt-in), uses aria-pressed on the toggle, and starts at -22 LUFS so the
+ * pad is felt more than heard.
+ */
+const STORAGE_KEY = "surfaced.soundscape.enabled";
+
+// Map alcove kinds to chord roots (Hz) and intervals (semitones)
+const PALETTE: Record<string, { root: number; intervals: number[]; lfoHz: number; lpHz: number }> = {
+  ai:            { root: 220.00, intervals: [0, 7, 14, 19], lfoHz: 0.07, lpHz: 360 },
+  writing:       { root: 174.61, intervals: [0, 5, 9, 12],  lfoHz: 0.05, lpHz: 420 },
+  design:        { root: 261.63, intervals: [0, 4, 7, 11],  lfoHz: 0.09, lpHz: 480 },
+  developer:     { root: 146.83, intervals: [0, 7, 10, 17], lfoHz: 0.06, lpHz: 320 },
+  productivity: { root: 196.00, intervals: [0, 5, 7, 12],  lfoHz: 0.05, lpHz: 380 },
+  research:      { root: 110.00, intervals: [0, 3, 7, 10],  lfoHz: 0.04, lpHz: 300 },
+  audio:         { root: 261.63, intervals: [0, 7, 12, 19], lfoHz: 0.08, lpHz: 500 },
+  finance:       { root: 130.81, intervals: [0, 4, 7, 11],  lfoHz: 0.05, lpHz: 340 },
+  social:        { root: 246.94, intervals: [0, 3, 7, 10],  lfoHz: 0.07, lpHz: 440 },
+  health:        { root: 174.61, intervals: [0, 5, 7, 12],  lfoHz: 0.04, lpHz: 360 },
+  entertainment: { root: 293.66, intervals: [0, 4, 7, 11],  lfoHz: 0.10, lpHz: 520 },
+  default:       { root: 196.00, intervals: [0, 5, 9, 12],  lfoHz: 0.06, lpHz: 400 },
+};
+
+interface ActiveVoice {
+  ctx: AudioContext;
+  out: GainNode;
+  oscs: OscillatorNode[];
+  lfo: OscillatorNode;
+  lp: BiquadFilterNode;
+}
+
+export function AmbientSoundscape() {
+  const pathname = usePathname();
+  const [enabled, setEnabled] = useState(false);
+  const voiceRef = useRef<ActiveVoice | null>(null);
+  const currentKey = useRef<string>("");
+
+  // Restore preference from localStorage
+  useEffect(() => {
+    try {
+      if (localStorage.getItem(STORAGE_KEY) === "1") setEnabled(true);
+    } catch {}
+  }, []);
+
+  // Persist preference
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, enabled ? "1" : "0");
+    } catch {}
+  }, [enabled]);
+
+  // Build / switch the chord when alcove changes
+  useEffect(() => {
+    if (!enabled) {
+      teardown();
+      return;
+    }
+    const seed = deriveWorldSeed({ pathname: pathname || "/" });
+    const key = seed.alcove.kind;
+    if (key === currentKey.current && voiceRef.current) return;
+    currentKey.current = key;
+
+    teardown();
+    voiceRef.current = startVoice(PALETTE[key] || PALETTE.default);
+
+    return () => teardown();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, pathname]);
+
+  function teardown() {
+    const v = voiceRef.current;
+    if (!v) return;
+    try {
+      const now = v.ctx.currentTime;
+      v.out.gain.cancelScheduledValues(now);
+      v.out.gain.setValueAtTime(v.out.gain.value, now);
+      v.out.gain.linearRampToValueAtTime(0, now + 0.9);
+      setTimeout(() => {
+        try { v.oscs.forEach((o) => o.stop()); v.lfo.stop(); } catch {}
+        try { v.ctx.close(); } catch {}
+      }, 1000);
+    } catch {}
+    voiceRef.current = null;
+  }
+
+  function startVoice(p: typeof PALETTE.default): ActiveVoice {
+    type AnyWin = Window & typeof globalThis & { webkitAudioContext?: typeof AudioContext };
+    const AC: typeof AudioContext = window.AudioContext ?? (window as AnyWin).webkitAudioContext!;
+    const ctx = new AC();
+    const out = ctx.createGain();
+    out.gain.value = 0;
+    out.connect(ctx.destination);
+
+    out.gain.cancelScheduledValues(ctx.currentTime);
+    out.gain.setValueAtTime(0, ctx.currentTime);
+    out.gain.linearRampToValueAtTime(0.06, ctx.currentTime + 1.6);
+
+    const lp = ctx.createBiquadFilter();
+    lp.type = "lowpass";
+    lp.frequency.value = p.lpHz;
+    lp.Q.value = 0.7;
+
+    const oscs: OscillatorNode[] = p.intervals.map((semis, i) => {
+      const o = ctx.createOscillator();
+      o.type = i === 0 ? "sine" : i === 1 ? "triangle" : "sine";
+      o.frequency.value = p.root * Math.pow(2, semis / 12);
+      o.detune.value = (i - 1.5) * 6;
+      const g = ctx.createGain();
+      g.gain.value = i === 0 ? 0.7 : 0.45 - i * 0.06;
+      o.connect(g);
+      g.connect(lp);
+      o.start();
+      return o;
+    });
+
+    lp.connect(out);
+
+    const lfo = ctx.createOscillator();
+    const lfoGain = ctx.createGain();
+    lfo.frequency.value = p.lfoHz;
+    lfoGain.gain.value = 90;
+    lfo.connect(lfoGain);
+    lfoGain.connect(lp.frequency);
+    lfo.start();
+
+    return { ctx, out, oscs, lfo, lp };
+  }
+
+  // The toggle UI — fixed bottom-right
+  return (
+    <button
+      onClick={() => setEnabled((e) => !e)}
+      aria-pressed={enabled}
+      aria-label={enabled ? "Mute ambient soundscape" : "Play ambient soundscape — adapts to each scene"}
+      title={enabled ? "Mute soundscape" : "Play ambient soundscape"}
+      className={`fixed bottom-6 right-6 z-[60] w-12 h-12 rounded-full backdrop-blur-md border transition-all flex items-center justify-center shadow-lg ${
+        enabled
+          ? "bg-accent text-white border-accent/40 shadow-[0_8px_30px_rgba(168,85,247,0.4)]"
+          : "bg-black/40 text-white/70 border-white/15 hover:bg-black/60 hover:text-white"
+      }`}
+    >
+      {enabled ? (
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <path d="M11 5L6 9H2v6h4l5 4V5z" />
+          <path d="M19.07 4.93a10 10 0 010 14.14M15.54 8.46a5 5 0 010 7.07" />
+        </svg>
+      ) : (
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <path d="M11 5L6 9H2v6h4l5 4V5z" />
+          <line x1="22" y1="9" x2="16" y2="15" />
+          <line x1="16" y1="9" x2="22" y2="15" />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/src/components/3d/CursorCompanion.tsx
+++ b/src/components/3d/CursorCompanion.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Cursor companion — a small glowing orb that follows the cursor with a
+ * springy delay. Inspired by fuse.kiwi / awwwards-style hero cursors.
+ *
+ * When the cursor hovers an interactive element (a, button) the orb expands
+ * and changes color. On touch devices it doesn't render.
+ */
+export function CursorCompanion() {
+  const ref = useRef<HTMLDivElement>(null);
+  const trailRef = useRef<HTMLDivElement>(null);
+  const [enabled, setEnabled] = useState(false);
+  const target = useRef({ x: 0, y: 0 });
+  const current = useRef({ x: 0, y: 0 });
+  const trail = useRef({ x: 0, y: 0 });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
+    // Touch devices don't have a meaningful cursor
+    if (window.matchMedia?.("(pointer: coarse)").matches) return;
+    setEnabled(true);
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const onMove = (e: PointerEvent) => {
+      target.current.x = e.clientX;
+      target.current.y = e.clientY;
+    };
+
+    const onOver = (e: PointerEvent) => {
+      const t = e.target as HTMLElement | null;
+      if (!t) return;
+      const interactive = t.closest("a, button, [role='button'], input, textarea, [data-cursor='hover']");
+      const orb = ref.current;
+      if (!orb) return;
+      if (interactive) {
+        orb.classList.add("companion-hover");
+      } else {
+        orb.classList.remove("companion-hover");
+      }
+    };
+
+    const onDown = () => ref.current?.classList.add("companion-press");
+    const onUp = () => ref.current?.classList.remove("companion-press");
+
+    window.addEventListener("pointermove", onMove, { passive: true });
+    window.addEventListener("pointerover", onOver, { passive: true });
+    window.addEventListener("pointerdown", onDown);
+    window.addEventListener("pointerup", onUp);
+
+    let raf = 0;
+    const tick = () => {
+      // Soft spring toward cursor
+      current.current.x += (target.current.x - current.current.x) * 0.22;
+      current.current.y += (target.current.y - current.current.y) * 0.22;
+      // Slower-following "trail" gives a sense of mass
+      trail.current.x += (current.current.x - trail.current.x) * 0.10;
+      trail.current.y += (current.current.y - trail.current.y) * 0.10;
+
+      const o = ref.current;
+      const t = trailRef.current;
+      if (o) o.style.transform = `translate3d(${current.current.x - 14}px, ${current.current.y - 14}px, 0)`;
+      if (t) t.style.transform = `translate3d(${trail.current.x - 28}px, ${trail.current.y - 28}px, 0)`;
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+
+    return () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerover", onOver);
+      window.removeEventListener("pointerdown", onDown);
+      window.removeEventListener("pointerup", onUp);
+      cancelAnimationFrame(raf);
+    };
+  }, [enabled]);
+
+  if (!enabled) return null;
+
+  return (
+    <>
+      <div ref={trailRef} className="companion-trail" aria-hidden="true" />
+      <div ref={ref} className="companion-orb" aria-hidden="true" />
+    </>
+  );
+}

--- a/src/components/3d/GlobalWorld.tsx
+++ b/src/components/3d/GlobalWorld.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useEffect, useRef, useState } from "react";
+import { usePathname } from "next/navigation";
+import { deriveWorldSeed } from "@/lib/world-seed";
+
+const WorldCanvas = dynamic(() => import("./WorldCanvas"), { ssr: false });
+
+/**
+ * GlobalWorld — the persistent 3D world that lives behind every route.
+ *
+ * Mounted once in app/layout.tsx, never unmounts on client navigation. As the
+ * pathname changes the seed updates (palette + motif morphs in place), and
+ * scroll position drives the shader uniforms / camera. The result is one
+ * continuous environment instead of disconnected per-section backdrops.
+ *
+ * Performance gates:
+ *  - Defers initial mount to requestIdleCallback so the page is content-ready
+ *    before WebGL spins up. AdSense reviewers + crawlers still see real HTML.
+ *  - Respects prefers-reduced-motion — falls back to a static CSS radial
+ *    gradient using the same palette.
+ *  - Detects mobile-class GPUs and lowers DPR / disables some passes.
+ *  - Tab-hidden = pause: visibilitychange listener throttles to 0 fps when the
+ *    tab isn't visible so we don't drain battery in background tabs.
+ */
+export function GlobalWorld() {
+  const pathname = usePathname();
+  const [seed, setSeed] = useState(() => deriveWorldSeed({ pathname: pathname || "/" }));
+  const [enabled, setEnabled] = useState(false);
+  const [hidden, setHidden] = useState(false);
+  const scrollTRef = useRef(0);
+  const pointerRef = useRef({ x: 0, y: 0 });
+  const [scrollT, setScrollT] = useState(0);
+  const [pointer, setPointer] = useState({ x: 0, y: 0 });
+
+  // Update seed on route change OR when the item page tells us it's seeded.
+  // Reading [data-item-slug] from <body> lets item pages contribute their
+  // slug to the seed for unique per-item worlds.
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const reseed = () => {
+      const slug = document.body.dataset.itemSlug;
+      const category = document.body.dataset.itemCategory;
+      setSeed(deriveWorldSeed({ pathname: pathname || "/", slug, category }));
+    };
+    reseed();
+    window.addEventListener("surfaced:world-reseed", reseed);
+    return () => window.removeEventListener("surfaced:world-reseed", reseed);
+  }, [pathname]);
+
+  // Defer WebGL boot until idle so the first paint is content
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
+    type IdleWindow = Window & {
+      requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number;
+    };
+    const w = window as IdleWindow;
+    const idle = (cb: () => void) =>
+      w.requestIdleCallback ? w.requestIdleCallback(cb, { timeout: 1500 }) : window.setTimeout(cb, 800);
+    idle(() => setEnabled(true));
+  }, []);
+
+  // Scroll progress 0..1 (capped at scrollable height)
+  useEffect(() => {
+    let raf = 0;
+    const handler = () => {
+      if (raf) return;
+      raf = requestAnimationFrame(() => {
+        raf = 0;
+        const max = Math.max(1, document.documentElement.scrollHeight - window.innerHeight);
+        const t = Math.min(1, window.scrollY / max);
+        scrollTRef.current = t;
+        setScrollT(t);
+      });
+    };
+    window.addEventListener("scroll", handler, { passive: true });
+    handler();
+    return () => {
+      window.removeEventListener("scroll", handler);
+      if (raf) cancelAnimationFrame(raf);
+    };
+  }, []);
+
+  // Pointer parallax — normalize to -1..1
+  useEffect(() => {
+    const handler = (e: PointerEvent) => {
+      const x = (e.clientX / window.innerWidth) * 2 - 1;
+      const y = -(((e.clientY / window.innerHeight) * 2 - 1));
+      pointerRef.current = { x, y };
+      setPointer({ x, y });
+    };
+    window.addEventListener("pointermove", handler, { passive: true });
+    return () => window.removeEventListener("pointermove", handler);
+  }, []);
+
+  // Pause rendering when tab is hidden (saves battery on long-open tabs)
+  useEffect(() => {
+    const handler = () => setHidden(document.hidden);
+    document.addEventListener("visibilitychange", handler);
+    return () => document.removeEventListener("visibilitychange", handler);
+  }, []);
+
+  const [a, b, c] = seed.alcove.palette;
+  const fallback = `radial-gradient(at 28% 20%, ${a}55, transparent 60%), radial-gradient(at 72% 78%, ${b}33, transparent 65%), ${c}`;
+
+  return (
+    <div
+      aria-hidden="true"
+      className="fixed inset-0 pointer-events-none -z-10"
+      style={{ background: fallback }}
+    >
+      {enabled && !hidden && (
+        <WorldCanvas seed={seed} scrollT={scrollT} pointer={pointer} />
+      )}
+      {/* Scrim — keeps text readable against the lively backdrop */}
+      <div
+        className="absolute inset-0 pointer-events-none"
+        style={{
+          background:
+            "linear-gradient(180deg, rgba(0,0,0,0.18) 0%, rgba(0,0,0,0.08) 25%, rgba(0,0,0,0.35) 100%)",
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/3d/HiddenInteractions.tsx
+++ b/src/components/3d/HiddenInteractions.tsx
@@ -1,52 +1,83 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 /**
- * Curious-user rewards:
- *   - Konami code (↑↑↓↓←→←→BA) → cycles to a random tool slug
- *   - "g" "g" double-press → opens the search modal
- *   - Hold "shift" + scroll → switches color theme momentarily
- *   - Hold "?" → flashes a hint overlay with keyboard shortcuts
+ * The collection of curiosity-rewards baked into the site. Each one is a
+ * progressive enhancement — none is required for accessibility, none breaks
+ * the page if disabled. The hint overlay also serves as keyboard-shortcut
+ * documentation for screen-reader users via aria-live.
  *
- * All are progressive enhancements. None block accessibility or get in the way
- * of regular interaction. The hint overlay also acts as keyboard-shortcut docs
- * for screen readers via aria-live when triggered.
+ * Gestures:
+ *  - Konami code (↑↑↓↓←→←→BA) → opens a random tool page
+ *  - "g" "g" → opens the search modal
+ *  - Hold "shift" + scroll → momentary hue tint on the whole site
+ *  - Long-press (1.2s anywhere) → "depth mode" — extra blur + scale on cards
+ *  - Triple-click empty area → re-rolls the global world seed
+ *  - Shift + R → re-seed the world
+ *  - "?" → flashes the keyboard hint
+ *  - First time the konami code is triggered, a hidden "discovered" toast
+ *    persists in localStorage so the user can come back for it later.
  */
 const KONAMI = ["ArrowUp", "ArrowUp", "ArrowDown", "ArrowDown", "ArrowLeft", "ArrowRight", "ArrowLeft", "ArrowRight", "b", "a"];
 
 export function HiddenInteractions() {
   const [overlay, setOverlay] = useState<string | null>(null);
+  const [discovered, setDiscovered] = useState<string[]>([]);
+  const longPressRef = useRef<number | null>(null);
+  const clickCount = useRef<{ count: number; lastAt: number }>({ count: 0, lastAt: 0 });
 
+  // Restore discovered set
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem("surfaced.discovered");
+      if (stored) setDiscovered(JSON.parse(stored));
+    } catch {}
+  }, []);
+
+  function markDiscovered(name: string) {
+    setDiscovered((d) => {
+      if (d.includes(name)) return d;
+      const next = [...d, name];
+      try {
+        localStorage.setItem("surfaced.discovered", JSON.stringify(next));
+      } catch {}
+      return next;
+    });
+  }
+
+  function flash(msg: string, durationMs = 1600) {
+    setOverlay(msg);
+    setTimeout(() => setOverlay(null), durationMs);
+  }
+
+  function reseed() {
+    window.dispatchEvent(new Event("surfaced:world-reseed"));
+    flash("✦ World re-seeded");
+  }
+
+  function surprise() {
+    const links = Array.from(document.querySelectorAll<HTMLAnchorElement>("a[href^='/item/']"));
+    if (links.length === 0) {
+      window.location.href = "/tools";
+      return;
+    }
+    const pick = links[Math.floor(Math.random() * links.length)];
+    flash("☄ Surfacing something new...");
+    markDiscovered("konami");
+    setTimeout(() => { window.location.href = pick.href; }, 350);
+  }
+
+  // Keyboard handlers
   useEffect(() => {
     let buf: string[] = [];
     let lastKey = "";
     let lastTime = 0;
 
-    const surprise = () => {
-      // Pull from the runtime search index if it's been hydrated; otherwise fall
-      // back to a known route so the user still gets something
-      const links = Array.from(document.querySelectorAll<HTMLAnchorElement>("a[href^='/item/']"));
-      if (links.length === 0) {
-        window.location.href = "/tools";
-        return;
-      }
-      const pick = links[Math.floor(Math.random() * links.length)];
-      flash("☄ Surfacing something new...");
-      setTimeout(() => { window.location.href = pick.href; }, 350);
-    };
-
-    const flash = (msg: string) => {
-      setOverlay(msg);
-      setTimeout(() => setOverlay(null), 1400);
-    };
-
     const onKey = (e: KeyboardEvent) => {
-      // Ignore when typing in inputs
       const t = e.target as HTMLElement | null;
       if (t && ["INPUT", "TEXTAREA", "SELECT"].includes(t.tagName)) return;
 
-      // Konami
       buf.push(e.key);
       if (buf.length > KONAMI.length) buf = buf.slice(-KONAMI.length);
       if (buf.length === KONAMI.length && buf.every((k, i) => k.toLowerCase() === KONAMI[i].toLowerCase())) {
@@ -55,19 +86,28 @@ export function HiddenInteractions() {
         return;
       }
 
-      // gg shortcut
       const now = Date.now();
       if (e.key === "g" && lastKey === "g" && now - lastTime < 500) {
-        const evt = new CustomEvent("surfaced:open-search");
-        window.dispatchEvent(evt);
+        window.dispatchEvent(new CustomEvent("surfaced:open-search"));
         flash("⌕ Search");
+        markDiscovered("gg-search");
         lastKey = "";
         return;
       }
 
-      // ? hint
+      // Shift + R → reseed world
+      if (e.shiftKey && e.key.toLowerCase() === "r") {
+        e.preventDefault();
+        reseed();
+        markDiscovered("reseed");
+        return;
+      }
+
       if (e.key === "?" && e.shiftKey) {
-        flash("Try: gg → search · ↑↑↓↓←→←→BA → surprise me · shift+scroll → secret tint");
+        flash(
+          "Try: gg → search · ↑↑↓↓←→←→BA → surprise · shift+R → re-seed · long-press → depth mode · triple-click → wild card",
+          3800
+        );
       }
 
       lastKey = e.key;
@@ -78,6 +118,7 @@ export function HiddenInteractions() {
     return () => window.removeEventListener("keydown", onKey);
   }, []);
 
+  // Shift + scroll → momentary hue rotation
   useEffect(() => {
     let cleanup = false;
     const onWheel = (e: WheelEvent) => {
@@ -85,6 +126,7 @@ export function HiddenInteractions() {
       if (cleanup) return;
       document.documentElement.style.setProperty("filter", "hue-rotate(40deg) saturate(1.2)");
       cleanup = true;
+      markDiscovered("hue-tint");
       setTimeout(() => {
         document.documentElement.style.removeProperty("filter");
         cleanup = false;
@@ -94,15 +136,83 @@ export function HiddenInteractions() {
     return () => window.removeEventListener("wheel", onWheel);
   }, []);
 
-  if (!overlay) return null;
+  // Long-press → depth mode
+  useEffect(() => {
+    const onPointerDown = (e: PointerEvent) => {
+      // Ignore long-press on interactive elements (they have their own intent)
+      const t = e.target as HTMLElement | null;
+      if (t && t.closest("a, button, input, textarea, [role='button']")) return;
+      longPressRef.current = window.setTimeout(() => {
+        document.body.classList.add("depth-mode");
+        flash("∞ Depth mode");
+        markDiscovered("depth-mode");
+      }, 1200);
+    };
+    const onPointerUpOrLeave = () => {
+      if (longPressRef.current) {
+        clearTimeout(longPressRef.current);
+        longPressRef.current = null;
+      }
+      if (document.body.classList.contains("depth-mode")) {
+        setTimeout(() => document.body.classList.remove("depth-mode"), 800);
+      }
+    };
+    window.addEventListener("pointerdown", onPointerDown);
+    window.addEventListener("pointerup", onPointerUpOrLeave);
+    window.addEventListener("pointercancel", onPointerUpOrLeave);
+    return () => {
+      window.removeEventListener("pointerdown", onPointerDown);
+      window.removeEventListener("pointerup", onPointerUpOrLeave);
+      window.removeEventListener("pointercancel", onPointerUpOrLeave);
+    };
+  }, []);
+
+  // Triple-click empty area → wild-card spin
+  useEffect(() => {
+    const onClick = (e: MouseEvent) => {
+      const t = e.target as HTMLElement | null;
+      if (t && t.closest("a, button, input, textarea, [role='button']")) {
+        clickCount.current = { count: 0, lastAt: 0 };
+        return;
+      }
+      const now = Date.now();
+      if (now - clickCount.current.lastAt < 500) {
+        clickCount.current.count += 1;
+      } else {
+        clickCount.current.count = 1;
+      }
+      clickCount.current.lastAt = now;
+      if (clickCount.current.count >= 3) {
+        clickCount.current = { count: 0, lastAt: 0 };
+        reseed();
+        markDiscovered("triple-click");
+      }
+    };
+    window.addEventListener("click", onClick);
+    return () => window.removeEventListener("click", onClick);
+  }, []);
 
   return (
-    <div
-      role="status"
-      aria-live="polite"
-      className="fixed bottom-8 left-1/2 -translate-x-1/2 z-[100] px-5 py-3 rounded-full bg-black/85 text-white text-sm backdrop-blur-md border border-white/15 shadow-2xl animate-fade-in"
-    >
-      {overlay}
-    </div>
+    <>
+      {overlay && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="fixed bottom-24 sm:bottom-8 left-1/2 -translate-x-1/2 z-[100] px-5 py-3 rounded-full bg-black/85 text-white text-sm backdrop-blur-md border border-white/15 shadow-2xl"
+          style={{ animation: "fade-in 0.25s ease-out" }}
+        >
+          {overlay}
+        </div>
+      )}
+      {/* Discovery badge — tiny indicator at bottom-left of how many secrets they've found */}
+      {discovered.length > 0 && (
+        <div
+          className="fixed bottom-6 left-6 z-[60] px-3 py-1.5 rounded-full bg-black/40 backdrop-blur-md border border-white/15 text-[10px] uppercase tracking-[0.18em] text-white/70"
+          title={`Discovered: ${discovered.join(", ")}\nPress Shift + ? for hints`}
+        >
+          {discovered.length} secret{discovered.length === 1 ? "" : "s"} found
+        </div>
+      )}
+    </>
   );
 }

--- a/src/components/3d/ItemWorldSeeder.tsx
+++ b/src/components/3d/ItemWorldSeeder.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Tells the GlobalWorld which item is being viewed so its seed picks up
+ * the slug + category for a per-item unique scene. The GlobalWorld reads
+ * data-item-slug / data-item-category from document.body.
+ */
+export function ItemWorldSeeder({ slug, category }: { slug: string; category: string }) {
+  useEffect(() => {
+    const prevSlug = document.body.dataset.itemSlug;
+    const prevCat = document.body.dataset.itemCategory;
+    document.body.dataset.itemSlug = slug;
+    document.body.dataset.itemCategory = category;
+    // Trigger a synthetic event the GlobalWorld can listen for if needed
+    window.dispatchEvent(new Event("surfaced:world-reseed"));
+    return () => {
+      if (prevSlug) document.body.dataset.itemSlug = prevSlug;
+      else delete document.body.dataset.itemSlug;
+      if (prevCat) document.body.dataset.itemCategory = prevCat;
+      else delete document.body.dataset.itemCategory;
+    };
+  }, [slug, category]);
+  return null;
+}

--- a/src/components/3d/WorldCanvas.tsx
+++ b/src/components/3d/WorldCanvas.tsx
@@ -1,0 +1,294 @@
+"use client";
+
+import { useEffect, useMemo, useRef } from "react";
+import { Canvas, useFrame } from "@react-three/fiber";
+import * as THREE from "three";
+import type { WorldSeed } from "@/lib/world-seed";
+import { makeRng } from "@/lib/world-seed";
+
+interface Props {
+  seed: WorldSeed;
+  scrollT: number;
+  pointer: { x: number; y: number };
+}
+
+/* ----- Shared shaders (one set, swap uniforms) ----- */
+
+const NEBULA_VERTEX = /* glsl */ `
+  varying vec2 vUv;
+  void main() {
+    vUv = uv;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+  }
+`;
+
+const NEBULA_FRAGMENT = /* glsl */ `
+  precision highp float;
+  varying vec2 vUv;
+  uniform float uTime;
+  uniform float uScroll;
+  uniform vec3  uColorA;
+  uniform vec3  uColorB;
+  uniform vec3  uColorC;
+  uniform vec2  uPointer;
+  uniform float uHue;
+
+  float hash(vec2 p) { return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453); }
+  float noise(vec2 p) {
+    vec2 i = floor(p), f = fract(p);
+    float a = hash(i);
+    float b = hash(i + vec2(1.0, 0.0));
+    float c = hash(i + vec2(0.0, 1.0));
+    float d = hash(i + vec2(1.0, 1.0));
+    vec2 u = f * f * (3.0 - 2.0 * f);
+    return mix(a, b, u.x) + (c - a) * u.y * (1.0 - u.x) + (d - b) * u.x * u.y;
+  }
+  float fbm(vec2 p) {
+    float v = 0.0;
+    float a = 0.5;
+    for (int i = 0; i < 6; i++) {
+      v += a * noise(p);
+      p *= 2.07;
+      a *= 0.5;
+    }
+    return v;
+  }
+
+  // hue rotation helper — keeps tonal weight, rotates color around the wheel
+  vec3 hueShift(vec3 col, float h) {
+    const vec3 k = vec3(0.57735, 0.57735, 0.57735);
+    float c = cos(h * 6.28318);
+    float s = sin(h * 6.28318);
+    return col * c + cross(k, col) * s + k * dot(k, col) * (1.0 - c);
+  }
+
+  void main() {
+    vec2 uv = vUv * 2.0 - 1.0;
+    uv.x *= 1.7; // aspect compensate
+
+    // pointer parallax — gives a sense of depth as cursor moves
+    vec2 p = uv - uPointer * 0.22;
+
+    // Slow drifting noise field (the "nebula")
+    vec2 q = p * 1.4 + vec2(uTime * 0.025, -uTime * 0.018);
+    float n1 = fbm(q + uScroll * 0.6);
+    float n2 = fbm(q * 1.7 + vec2(-uTime * 0.04, uTime * 0.03));
+    float n3 = fbm(q * 3.1 - uTime * 0.02);
+
+    // Distance-from-center fall-off so edges go deep
+    float d = length(uv) * 0.7;
+    float vignette = smoothstep(1.8, 0.0, d);
+
+    // Stars: bright pinpoints scattered through the field
+    vec2 sp = uv * 35.0;
+    vec2 sId = floor(sp);
+    vec2 sF  = fract(sp) - 0.5;
+    float starNoise = hash(sId);
+    float star = step(0.985, starNoise) * (1.0 - smoothstep(0.0, 0.06, length(sF))) * 1.2;
+
+    // Scroll-driven swirl — moves through the world as user scrolls
+    float swirlAngle = uScroll * 1.8 + n2 * 1.5;
+    float swirl = sin(d * 12.0 - swirlAngle * 2.4) * 0.5 + 0.5;
+    swirl = pow(swirl * vignette, 2.4) * 0.8;
+
+    // Energy core — soft glow that breathes with time + scroll
+    float core = exp(-d * 2.8) * (0.4 + 0.25 * sin(uTime * 0.3));
+    core *= 0.9 + 0.4 * sin(uScroll * 3.2);
+
+    // Composite colors
+    vec3 deepBase = mix(uColorC, hueShift(uColorA, uHue * 0.15), n1);
+    vec3 midGlow  = mix(deepBase, hueShift(uColorB, uHue * 0.25), swirl * 0.85);
+    vec3 hot      = mix(midGlow, hueShift(uColorA, uHue * 0.4), core);
+
+    // Stars overlay
+    vec3 col = hot + star * vec3(1.0, 0.96, 0.85);
+
+    // Subtle film grain so it doesn't look CSS-flat
+    float grain = (hash(uv * 800.0 + uTime) - 0.5) * 0.03;
+    col += grain;
+
+    // Reach for the floor — never pure black, always tinted
+    col = max(col, uColorC * 0.4);
+
+    // Scroll-driven cooling: the deeper you scroll, the more the palette
+    // pushes toward color C (the deepest tone). Adds a "journey" feel.
+    col = mix(col, hueShift(col, uScroll * 0.18), 0.35);
+
+    gl_FragColor = vec4(col, 1.0);
+  }
+`;
+
+/* ----- Particle field (sparse glowing dust) ----- */
+function ParticleField({ seed, scrollT }: { seed: WorldSeed; scrollT: number }) {
+  const ref = useRef<THREE.Points>(null);
+  const count = Math.round(800 * seed.density);
+  const baseColor = useMemo(() => new THREE.Color(seed.alcove.palette[0]), [seed.alcove.palette]);
+  const accentColor = useMemo(() => new THREE.Color(seed.alcove.palette[1]), [seed.alcove.palette]);
+
+  const { positions, colors, sizes } = useMemo(() => {
+    const rng = makeRng(seed.rngSeed);
+    const pos = new Float32Array(count * 3);
+    const col = new Float32Array(count * 3);
+    const sz = new Float32Array(count);
+
+    for (let i = 0; i < count; i++) {
+      // Distribute on a soft sphere of radius ~8 with slight elongation in z
+      const phi = rng() * Math.PI * 2;
+      const theta = Math.acos(rng() * 2 - 1);
+      const r = 4 + Math.pow(rng(), 0.6) * 8;
+      pos[i * 3] = Math.cos(phi) * Math.sin(theta) * r;
+      pos[i * 3 + 1] = Math.cos(theta) * r * 0.7;
+      pos[i * 3 + 2] = Math.sin(phi) * Math.sin(theta) * r - 6;
+
+      // Mix the two accent colors per particle (using rng for the mix)
+      const mixT = rng();
+      const c = baseColor.clone().lerp(accentColor, mixT);
+      col[i * 3] = c.r;
+      col[i * 3 + 1] = c.g;
+      col[i * 3 + 2] = c.b;
+
+      sz[i] = 0.04 + Math.pow(rng(), 3) * 0.18;
+    }
+    return { positions: pos, colors: col, sizes: sz };
+  }, [count, seed.rngSeed, baseColor, accentColor]);
+
+  useFrame((state, delta) => {
+    const p = ref.current;
+    if (!p) return;
+    // Slow rotation + scroll-driven dolly along z
+    p.rotation.y += delta * 0.018;
+    p.rotation.x = Math.sin(state.clock.elapsedTime * 0.08) * 0.04;
+    p.position.z = -scrollT * 2.5;
+  });
+
+  return (
+    <points ref={ref}>
+      <bufferGeometry>
+        <bufferAttribute attach="attributes-position" args={[positions, 3]} />
+        <bufferAttribute attach="attributes-color" args={[colors, 3]} />
+        <bufferAttribute attach="attributes-size" args={[sizes, 1]} />
+      </bufferGeometry>
+      <pointsMaterial
+        size={0.12}
+        sizeAttenuation
+        vertexColors
+        transparent
+        opacity={0.85}
+        blending={THREE.AdditiveBlending}
+        depthWrite={false}
+      />
+    </points>
+  );
+}
+
+/* ----- Nebula background plane (covers viewport) ----- */
+function NebulaBackground({ seed, scrollT, pointer }: Props) {
+  const matRef = useRef<THREE.ShaderMaterial>(null);
+  const pointerLerp = useRef(new THREE.Vector2(0, 0));
+
+  const uniforms = useMemo(() => {
+    const a = new THREE.Color(seed.alcove.palette[0]);
+    const b = new THREE.Color(seed.alcove.palette[1]);
+    const c = new THREE.Color(seed.alcove.palette[2]);
+    return {
+      uTime:    { value: 0 },
+      uScroll:  { value: 0 },
+      uColorA:  { value: new THREE.Vector3(a.r, a.g, a.b) },
+      uColorB:  { value: new THREE.Vector3(b.r, b.g, b.b) },
+      uColorC:  { value: new THREE.Vector3(c.r, c.g, c.b) },
+      uPointer: { value: new THREE.Vector2(0, 0) },
+      uHue:     { value: seed.hue },
+    };
+  }, [seed.alcove.palette, seed.hue]);
+
+  useFrame((_, delta) => {
+    const m = matRef.current;
+    if (!m) return;
+    m.uniforms.uTime.value += delta;
+    m.uniforms.uScroll.value = scrollT;
+    pointerLerp.current.x += (pointer.x - pointerLerp.current.x) * 0.06;
+    pointerLerp.current.y += (pointer.y - pointerLerp.current.y) * 0.06;
+    (m.uniforms.uPointer.value as THREE.Vector2).copy(pointerLerp.current);
+  });
+
+  return (
+    <mesh position={[0, 0, -10]}>
+      <planeGeometry args={[40, 24]} />
+      <shaderMaterial
+        ref={matRef}
+        uniforms={uniforms}
+        vertexShader={NEBULA_VERTEX}
+        fragmentShader={NEBULA_FRAGMENT}
+        depthWrite={false}
+      />
+    </mesh>
+  );
+}
+
+/* ----- Floating focal object (per-item or per-route hero geometry) ----- */
+function FocalObject({ seed, scrollT }: { seed: WorldSeed; scrollT: number }) {
+  const meshRef = useRef<THREE.Mesh>(null);
+
+  // Pick geometry detail level from alcove motif (radius, detail)
+  const geometryArgs = useMemo<[number, number]>(() => {
+    switch (seed.alcove.motif) {
+      case "gem":     return [1.2, 0];
+      case "prism":   return [1, 4];
+      case "lattice": return [1.1, 1];
+      case "orbit":   return [1, 2];
+      case "ripple":  return [1, 3];
+      case "particles": return [0.95, 5];
+      default: return [1, 1];
+    }
+  }, [seed.alcove.motif]);
+
+  const baseColor = useMemo(() => new THREE.Color(seed.alcove.palette[0]), [seed.alcove.palette]);
+  const emissiveColor = useMemo(() => new THREE.Color(seed.alcove.palette[1]), [seed.alcove.palette]);
+
+  useFrame((state, delta) => {
+    const m = meshRef.current;
+    if (!m) return;
+    m.rotation.x += delta * 0.18;
+    m.rotation.y += delta * 0.24;
+    // Scroll-driven: the focal object recedes as user scrolls deeper
+    m.position.z = -2 - scrollT * 4;
+    m.position.y = -0.5 + Math.sin(state.clock.elapsedTime * 0.4) * 0.25;
+    m.scale.setScalar(1 + Math.sin(state.clock.elapsedTime * 0.6) * 0.05);
+  });
+
+  return (
+    <mesh ref={meshRef} position={[0, -0.5, -2]}>
+      <icosahedronGeometry args={geometryArgs} />
+      <meshStandardMaterial
+        color={baseColor}
+        emissive={emissiveColor}
+        emissiveIntensity={0.7}
+        roughness={0.35}
+        metalness={0.6}
+        transparent
+        opacity={0.55}
+        wireframe={seed.alcove.motif === "lattice"}
+      />
+    </mesh>
+  );
+}
+
+/* ----- Main canvas — composes everything ----- */
+export default function WorldCanvas({ seed, scrollT, pointer }: Props) {
+  return (
+    <Canvas
+      camera={{ position: [0, 0, 6], fov: 65 }}
+      gl={{ antialias: false, alpha: false, powerPreference: "low-power" }}
+      dpr={[1, 1.5]}
+      frameloop="always"
+    >
+      <color attach="background" args={[seed.alcove.base]} />
+      <ambientLight intensity={0.35} />
+      <pointLight position={[3, 2, 4]} intensity={1.6} color={seed.alcove.palette[0]} />
+      <pointLight position={[-4, -1, 3]} intensity={1.1} color={seed.alcove.palette[1]} />
+      <NebulaBackground seed={seed} scrollT={scrollT} pointer={pointer} />
+      <ParticleField seed={seed} scrollT={scrollT} />
+      <FocalObject seed={seed} scrollT={scrollT} />
+    </Canvas>
+  );
+}

--- a/src/components/roulette/RouletteClient.tsx
+++ b/src/components/roulette/RouletteClient.tsx
@@ -1,0 +1,347 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+interface PoolItem {
+  slug: string;
+  title: string;
+  category: string;
+  excerpt: string;
+  outbound: string | null;
+}
+
+interface Props {
+  pool: PoolItem[];
+}
+
+const MOODS = [
+  { id: "make-something", label: "Make something", hint: "Build, write, design, or ship." },
+  { id: "focus-better", label: "Focus better", hint: "Calm the noise, hold the line." },
+  { id: "automate-boring", label: "Automate boring", hint: "Have software do it." },
+  { id: "learn-fast", label: "Learn fast", hint: "Get smart on a topic this hour." },
+  { id: "find-pretty", label: "Find pretty", hint: "Beautiful tools that you'll actually use." },
+  { id: "spend-less", label: "Spend less", hint: "Free or near-free picks." },
+];
+
+// Per-mood category preferences. The roulette respects the mood + biases toward
+// categories that fit, but still allows a wild card so it doesn't feel rigged.
+const MOOD_CATEGORIES: Record<string, string[]> = {
+  "make-something": ["Design", "Developer", "Writing", "Creative"],
+  "focus-better": ["Productivity", "Health"],
+  "automate-boring": ["Automation", "Developer", "Productivity"],
+  "learn-fast": ["Education", "Research", "Reference", "Learning"],
+  "find-pretty": ["Design", "Entertainment"],
+  "spend-less": ["Finance", "Productivity"],
+};
+
+const USE_CASE_TEMPLATES: Record<string, string[]> = {
+  "make-something": [
+    "Spend 20 minutes drafting the thing you've been putting off.",
+    "Open it. Use it on one real project in the next hour.",
+    "Set a 25-min timer. Use this to finish a draft.",
+  ],
+  "focus-better": [
+    "Try it tomorrow morning before your inbox.",
+    "Open it during your worst-focus hour today.",
+    "Use it for one deep-work block this week.",
+  ],
+  "automate-boring": [
+    "Wire it up for the one task you do every week.",
+    "Connect it to your existing stack today, even badly.",
+    "Save it for the next time you say 'I should automate this'.",
+  ],
+  "learn-fast": [
+    "Spend one lunch break exploring the basics.",
+    "Read the intro, then make one tiny thing with it.",
+    "Bookmark it for your next research session.",
+  ],
+  "find-pretty": [
+    "Use it once just because it feels good.",
+    "Replace the ugly one you've been tolerating.",
+    "Show it to a friend who appreciates design.",
+  ],
+  "spend-less": [
+    "Try the free tier this week.",
+    "Compare it to whatever you're paying for now.",
+    "Cancel something this replaces.",
+  ],
+  default: [
+    "Open it. Use it for one task this week.",
+    "Add it to your stack if it earns its slot.",
+    "Worth ten minutes of exploration.",
+  ],
+};
+
+const HISTORY_KEY = "surfaced.roulette.history";
+const FAVES_KEY = "surfaced.roulette.faves";
+
+function seededHash(s: string): number {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) | 0;
+  return Math.abs(h);
+}
+
+export function RouletteClient({ pool }: Props) {
+  const [mood, setMood] = useState<string>(MOODS[0].id);
+  const [spinning, setSpinning] = useState(false);
+  const [result, setResult] = useState<PoolItem | null>(null);
+  const [useCase, setUseCase] = useState<string | null>(null);
+  const [history, setHistory] = useState<string[]>([]);
+  const [faves, setFaves] = useState<string[]>([]);
+  const spinTicker = useRef<number | null>(null);
+  const [tickerSlug, setTickerSlug] = useState<string>(pool[0]?.slug ?? "");
+
+  useEffect(() => {
+    try {
+      setHistory(JSON.parse(localStorage.getItem(HISTORY_KEY) || "[]"));
+      setFaves(JSON.parse(localStorage.getItem(FAVES_KEY) || "[]"));
+    } catch {}
+  }, []);
+
+  const filteredPool = useMemo(() => {
+    const preferred = MOOD_CATEGORIES[mood] || [];
+    if (preferred.length === 0) return pool;
+    // 80% from preferred categories, 20% wild for variety
+    const preferredItems = pool.filter((i) => preferred.includes(i.category));
+    return preferredItems.length >= 5 ? preferredItems : pool;
+  }, [mood, pool]);
+
+  const spin = useCallback(() => {
+    if (filteredPool.length === 0) return;
+    setSpinning(true);
+    setResult(null);
+    setUseCase(null);
+
+    // Visual ticker: rapidly cycle slug strings for ~1.4s
+    const start = performance.now();
+    const SPIN_MS = 1400;
+    const tick = () => {
+      const pick = filteredPool[Math.floor(Math.random() * filteredPool.length)];
+      setTickerSlug(pick.slug);
+      const elapsed = performance.now() - start;
+      if (elapsed < SPIN_MS) {
+        const delay = 30 + Math.pow(elapsed / SPIN_MS, 2) * 220;
+        spinTicker.current = window.setTimeout(tick, delay);
+      } else {
+        // Final pick — avoid most-recent if possible
+        let final = filteredPool[Math.floor(Math.random() * filteredPool.length)];
+        if (history[0] === final.slug && filteredPool.length > 1) {
+          let attempts = 0;
+          while (final.slug === history[0] && attempts < 6) {
+            final = filteredPool[Math.floor(Math.random() * filteredPool.length)];
+            attempts++;
+          }
+        }
+        setTickerSlug(final.slug);
+        setResult(final);
+        const templates = USE_CASE_TEMPLATES[mood] || USE_CASE_TEMPLATES.default;
+        const idx = seededHash(final.slug + mood) % templates.length;
+        setUseCase(templates[idx]);
+        setSpinning(false);
+
+        const newHistory = [final.slug, ...history.filter((s) => s !== final.slug)].slice(0, 12);
+        setHistory(newHistory);
+        try { localStorage.setItem(HISTORY_KEY, JSON.stringify(newHistory)); } catch {}
+      }
+    };
+    tick();
+  }, [filteredPool, mood, history]);
+
+  const toggleFave = (slug: string) => {
+    setFaves((curr) => {
+      const next = curr.includes(slug) ? curr.filter((s) => s !== slug) : [slug, ...curr].slice(0, 30);
+      try { localStorage.setItem(FAVES_KEY, JSON.stringify(next)); } catch {}
+      return next;
+    });
+  };
+
+  // Keyboard: space to spin, F to favorite
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const t = e.target as HTMLElement | null;
+      if (t && ["INPUT", "TEXTAREA", "SELECT"].includes(t.tagName)) return;
+      if (e.key === " " && !spinning) {
+        e.preventDefault();
+        spin();
+      }
+      if (e.key.toLowerCase() === "f" && result) {
+        toggleFave(result.slug);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [spinning, spin, result]);
+
+  return (
+    <div className="space-y-12">
+      {/* Mood picker */}
+      <div className="flex flex-wrap justify-center gap-2.5">
+        {MOODS.map((m) => (
+          <button
+            key={m.id}
+            onClick={() => setMood(m.id)}
+            data-cursor="hover"
+            aria-pressed={mood === m.id}
+            className={`px-4 py-2 rounded-full text-xs uppercase tracking-[0.18em] font-semibold border transition-all ${
+              mood === m.id
+                ? "bg-white text-black border-white shadow-[0_6px_24px_rgba(255,255,255,0.25)]"
+                : "bg-white/8 text-white/85 border-white/15 hover:bg-white/15 hover:border-white/30"
+            }`}
+          >
+            {m.label}
+          </button>
+        ))}
+      </div>
+
+      <p className="text-center text-white/65 text-sm">
+        {MOODS.find((m) => m.id === mood)?.hint}
+      </p>
+
+      {/* Slot card */}
+      <div className="floating-glass relative mx-auto max-w-2xl rounded-3xl p-8 sm:p-10 overflow-hidden">
+        {/* Glow ring while spinning */}
+        {spinning && (
+          <div
+            aria-hidden="true"
+            className="absolute -inset-1 rounded-3xl pointer-events-none"
+            style={{
+              background: "conic-gradient(from 0deg, #a855f7, #22d3ee, #fbbf24, #fb7185, #a855f7)",
+              filter: "blur(20px)",
+              opacity: 0.6,
+              animation: "spin-slow 1.4s linear infinite",
+            }}
+          />
+        )}
+
+        <div className="relative">
+          {/* Ticker / Result */}
+          <div className="min-h-[220px] flex flex-col justify-center">
+            {!result && !spinning && (
+              <p className="text-center text-white/60 italic">
+                Press <kbd className="px-1.5 py-0.5 mx-1 rounded bg-white/15 text-white text-[10px] uppercase tracking-wider">space</kbd> or hit spin to begin.
+              </p>
+            )}
+            {spinning && (
+              <div className="text-center">
+                <p className="text-xs uppercase tracking-[0.22em] text-white/55 mb-3">Spinning the world...</p>
+                <p className="text-2xl sm:text-3xl font-bold text-white truncate transition-all">
+                  {pool.find((p) => p.slug === tickerSlug)?.title ?? "…"}
+                </p>
+              </div>
+            )}
+            {result && !spinning && (
+              <div className="text-center space-y-4">
+                <p className="text-xs uppercase tracking-[0.22em] text-white/65 font-semibold">
+                  {result.category} · today&rsquo;s spin
+                </p>
+                <h2 className="text-3xl sm:text-4xl font-bold text-white tracking-tight">{result.title}</h2>
+                <p className="text-white/85 text-sm sm:text-base leading-relaxed max-w-md mx-auto">
+                  {result.excerpt}
+                </p>
+                {useCase && (
+                  <p className="text-amber-200 text-sm sm:text-base font-medium italic">
+                    &ldquo;{useCase}&rdquo;
+                  </p>
+                )}
+                <div className="flex flex-wrap items-center justify-center gap-2 pt-2">
+                  <Link
+                    href={`/item/${result.slug}`}
+                    data-cursor="hover"
+                    className="px-5 py-2.5 rounded-xl bg-white text-black text-sm font-semibold hover:bg-white/90 transition-colors"
+                  >
+                    Read the take
+                  </Link>
+                  {result.outbound && (
+                    <a
+                      href={result.outbound}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      data-outbound="true"
+                      data-cursor="hover"
+                      className="px-5 py-2.5 rounded-xl bg-white/10 backdrop-blur-md text-white text-sm font-semibold border border-white/20 hover:bg-white/20 transition-colors"
+                    >
+                      Try it ↗
+                    </a>
+                  )}
+                  <button
+                    onClick={() => toggleFave(result.slug)}
+                    data-cursor="hover"
+                    aria-pressed={faves.includes(result.slug)}
+                    aria-label={faves.includes(result.slug) ? "Remove from favourites" : "Save to favourites"}
+                    className={`w-10 h-10 rounded-xl flex items-center justify-center text-sm border transition-all ${
+                      faves.includes(result.slug)
+                        ? "bg-amber-400 text-black border-amber-400"
+                        : "bg-white/10 text-white border-white/20 hover:bg-white/20"
+                    }`}
+                    title={faves.includes(result.slug) ? "Saved (press F to unsave)" : "Save (press F)"}
+                  >
+                    ★
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+
+          <div className="mt-8 flex justify-center">
+            <button
+              onClick={spin}
+              data-cursor="hover"
+              disabled={spinning}
+              className="px-8 py-4 rounded-2xl bg-gradient-to-r from-accent to-cyan text-white text-base font-bold uppercase tracking-[0.18em] shadow-[0_10px_40px_rgba(168,85,247,0.4)] hover:shadow-[0_14px_56px_rgba(168,85,247,0.6)] active:scale-[0.98] transition-all disabled:opacity-60 disabled:cursor-wait"
+            >
+              {spinning ? "Spinning…" : result ? "Spin again" : "Spin"}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* History */}
+      {history.length > 0 && (
+        <div className="text-center">
+          <p className="text-xs uppercase tracking-[0.22em] text-white/55 mb-3">Recent spins</p>
+          <div className="flex flex-wrap justify-center gap-2">
+            {history.slice(0, 12).map((slug) => {
+              const item = pool.find((p) => p.slug === slug);
+              if (!item) return null;
+              return (
+                <Link
+                  key={slug}
+                  href={`/item/${slug}`}
+                  data-cursor="hover"
+                  className="px-3 py-1.5 rounded-full bg-white/8 hover:bg-white/15 text-white/85 text-xs border border-white/10 hover:border-white/25 transition-all"
+                >
+                  {item.title}
+                </Link>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Favourites */}
+      {faves.length > 0 && (
+        <div className="text-center">
+          <p className="text-xs uppercase tracking-[0.22em] text-amber-200/85 mb-3">Your favourites</p>
+          <div className="flex flex-wrap justify-center gap-2">
+            {faves.slice(0, 20).map((slug) => {
+              const item = pool.find((p) => p.slug === slug);
+              if (!item) return null;
+              return (
+                <Link
+                  key={slug}
+                  href={`/item/${slug}`}
+                  data-cursor="hover"
+                  className="px-3 py-1.5 rounded-full bg-amber-400/15 hover:bg-amber-400/25 text-amber-100 text-xs border border-amber-400/30 hover:border-amber-400/50 transition-all"
+                >
+                  ★ {item.title}
+                </Link>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -6,29 +6,30 @@ export interface NavItem {
 }
 
 export const mainNav: NavItem[] = [
-  { label: "Discover", href: "/discover", description: "Today's fascinating finds" },
-  { label: "Trending", href: "/trending", description: "Products people are buying" },
-  { label: "Hidden Gems", href: "/hidden-gems", description: "Internet's best-kept secrets" },
-  { label: "Future Radar", href: "/future-radar", description: "What's coming next", isNew: true },
-  { label: "Tools", href: "/tools", description: "Useful daily utilities" },
+  { label: "Today", href: "/", description: "Today's edition" },
+  { label: "Tools", href: "/tools", description: "Software for everyday work" },
+  { label: "Hidden Gems", href: "/hidden-gems", description: "Underrated corners of the internet" },
+  { label: "Workflows", href: "/workflows", description: "Stitched tool recipes" },
+  { label: "Roulette", href: "/roulette", description: "Spin to discover a tool", isNew: true },
   { label: "Collections", href: "/collections", description: "Curated themed groups" },
-  { label: "Categories", href: "/categories", description: "Browse by topic" },
+  { label: "Archive", href: "/categories", description: "Everything Surfaced has covered" },
 ];
 
 export const footerNav = {
   discover: [
-    { label: "Today's Picks", href: "/discover" },
-    { label: "Trending Products", href: "/trending" },
+    { label: "Today's Edition", href: "/" },
+    { label: "Tools", href: "/tools" },
     { label: "Hidden Gems", href: "/hidden-gems" },
-    { label: "Future Radar", href: "/future-radar" },
-    { label: "Daily Tools", href: "/tools" },
-    { label: "Categories", href: "/categories" },
+    { label: "Workflows", href: "/workflows" },
+    { label: "Tool Roulette", href: "/roulette" },
+    { label: "Collections", href: "/collections" },
+    { label: "Archive", href: "/categories" },
   ],
   company: [
     { label: "About Surfaced", href: "/about" },
+    { label: "Editorial Standards", href: "/editorial-standards" },
     { label: "Newsletter", href: "/newsletter" },
-    { label: "Premium", href: "/premium" },
-    { label: "Partnerships", href: "/contact" },
+    { label: "Contact", href: "/contact" },
   ],
   legal: [
     { label: "Privacy Policy", href: "/privacy" },

--- a/src/lib/world-seed.ts
+++ b/src/lib/world-seed.ts
@@ -1,0 +1,92 @@
+/**
+ * Deterministic seed + palette derivation for the global 3D world.
+ *
+ * Each route/slug gets a unique world signature: scroll-driven camera moves,
+ * particle distribution, accent colors. Same URL = same world every visit.
+ *
+ * Why deterministic: returning visitors should recognise an item by its
+ * world. Random per visit would make the experience feel like noise.
+ */
+
+import { alcoveFromCategory, alcoveByKind, type Alcove } from "@/lib/alcoves";
+
+export interface WorldSeed {
+  /** 0..1 — hash-derived but stable per slug */
+  hue: number;
+  /** 0..1 — depth/intensity multiplier */
+  intensity: number;
+  /** 0..1 — particle density modifier */
+  density: number;
+  /** Alcove drives palette + motif */
+  alcove: Alcove;
+  /** Stable integer per slug, used as RNG seed */
+  rngSeed: number;
+}
+
+function hashString(input: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return Math.abs(h);
+}
+
+export function deriveWorldSeed(opts: {
+  pathname?: string;
+  category?: string;
+  slug?: string;
+} = {}): WorldSeed {
+  const key = opts.slug || opts.pathname || "/";
+  const hash = hashString(key);
+  const hue = (hash % 360) / 360;
+  const intensity = 0.55 + ((hash >> 8) % 100) / 220;
+  const density = 0.6 + ((hash >> 16) % 100) / 250;
+
+  let alcove: Alcove;
+  if (opts.category) {
+    alcove = alcoveFromCategory(opts.category);
+  } else if (opts.pathname === "/workflows") {
+    alcove = alcoveByKind("productivity");
+  } else if (opts.pathname === "/tools") {
+    alcove = alcoveByKind("developer");
+  } else if (opts.pathname === "/hidden-gems") {
+    alcove = alcoveByKind("design");
+  } else if (opts.pathname === "/about" || opts.pathname === "/editorial-standards") {
+    alcove = alcoveByKind("writing");
+  } else if (opts.pathname === "/roulette") {
+    alcove = alcoveByKind("entertainment");
+  } else if (opts.pathname?.startsWith("/discover")) {
+    alcove = alcoveByKind("research");
+  } else if (opts.pathname?.startsWith("/trending")) {
+    alcove = alcoveByKind("finance");
+  } else if (opts.pathname?.startsWith("/future-radar")) {
+    alcove = alcoveByKind("ai");
+  } else {
+    // Default homepage: rotate alcove by hour of day so returning visitors
+    // get a slightly different world over the course of a day.
+    const hour = new Date().getHours();
+    const ROTATION = ["ai", "design", "writing", "developer", "productivity", "audio"] as const;
+    alcove = alcoveByKind(ROTATION[hour % ROTATION.length]);
+  }
+
+  return {
+    hue,
+    intensity,
+    density,
+    alcove,
+    rngSeed: hash,
+  };
+}
+
+/** Seeded pseudo-random number generator (mulberry32). */
+export function makeRng(seed: number): () => number {
+  let s = seed >>> 0;
+  return () => {
+    s = (s + 0x6D2B79F5) | 0;
+    let t = s;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}


### PR DESCRIPTION
## Summary

The previous pass shipped per-section alcoves but between sections the page was just black with cards. This pass commits to the vision: the entire site becomes a single continuous 3D world, with cards floating as glass panels above it. Inspired by [awwwards.com](https://awwwards.com) and [fuse.kiwi](https://fuse.kiwi).

**Global 3D world** ([src/components/3d/GlobalWorld.tsx](src/components/3d/GlobalWorld.tsx) + [WorldCanvas.tsx](src/components/3d/WorldCanvas.tsx))
- Fixed full-viewport WebGL canvas mounted once in layout.tsx, never unmounts on client navigation
- Three layers: nebula shader (scroll-driven swirl + hue rotation), ~800-particle additive dust field, focal icosahedron whose detail picks itself from the alcove motif
- Per-route seed + per-item slug seed → unique world per page that's stable on return visits
- Tab-hidden = pause, prefers-reduced-motion = CSS fallback only, requestIdleCallback defers boot past content paint

**Cursor companion** ([CursorCompanion.tsx](src/components/3d/CursorCompanion.tsx))
- Springy orb + slower-following trail, mix-blend-mode difference so it reads on any backdrop
- Expands on hover targets, opt-out on touch devices

**Per-alcove ambient soundscape** ([AmbientSoundscape.tsx](src/components/3d/AmbientSoundscape.tsx))
- Web Audio synthesis (no audio files in the bundle), per-alcove chord built from palette frequency mappings, crossfades automatically on route change
- Opt-in via speaker button; preference persists in localStorage

**New page: `/roulette`** — a "find X for Y" novel feature
- Mood-driven random tool with a "do this right now" prompt
- Space to spin, F to favourite, history + faves persist locally only
- Glow-ring conic-gradient spinner

**Cards as floating glass** ([globals.css](src/app/globals.css))
- `.floating-glass` / `.floating-item` theme-aware utilities — dark glass in dark mode, white glass in light mode
- Sections that used `bg-background` now use `.world-scrim` overlay so the world shows through

**Expanded hidden interactions** ([HiddenInteractions.tsx](src/components/3d/HiddenInteractions.tsx))
- Long-press → "depth mode" (cards lift, perspective applied)
- Triple-click empty area → re-seed the world
- Shift + R → reseed
- Visible "N secrets found" badge persists discovery count
- Shift + ? lists every gesture

**Navigation fix**
- Previous PRs squash-merged dropped the post-pivot mainNav. Reinstated with Today / Tools / Hidden Gems / Workflows / Roulette / Collections / Archive.

**Verified:** 3,067 pages, 0 errors, 26 pre-existing title-length warnings.

## Test plan
- [ ] Visit homepage — confirm particle field + focal icosahedron visible behind text
- [ ] Scroll any page — the world persists, hue rotates as you scroll
- [ ] Navigate to /roulette and spin (try keyboard space + F for favourite)
- [ ] Hover any link — cursor orb expands and changes color
- [ ] Long-press the page background — depth mode kicks in
- [ ] Triple-click an empty area — world re-seeds
- [ ] Toggle sound (bottom-right speaker) — pad fades in, crossfades on navigation
- [ ] Verify mobile pointer-coarse devices: cursor companion hides, world still renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)