### PR TITLE
Layer soundscape through scroll phases

### DIFF
--- a/src/components/3d/AmbientSoundscape.tsx
+++ b/src/components/3d/AmbientSoundscape.tsx
@@ -2,169 +2,449 @@
 
 import { useEffect, useRef, useState } from "react";
 import { usePathname } from "next/navigation";
-import { deriveWorldSeed } from "@/lib/world-seed";
+import { deriveWorldSeed, type WorldSeed } from "@/lib/world-seed";
+import {
+  ITEM_KEYFRAMES,
+  clamp01,
+  getWorldPhaseTelemetry,
+  type WorldPhaseTelemetry,
+} from "@/lib/world-phase";
 
 /**
- * Ambient soundscape — pure Web Audio synthesis (no audio files shipped).
- * Each route gets a unique chord built from the alcove palette's frequency
- * mapping. Crossfades smoothly when the user navigates.
+ * Scroll-locked layered soundscape.
  *
- * Strictly opt-in: silent until the user clicks the speaker toggle. Once
- * enabled, the preference persists in localStorage and follows the user
- * across routes. Toggle is always visible bottom-right.
- *
- * Accessibility: respects prefers-reduced-motion as a hint (still allows
- * opt-in), uses aria-pressed on the toggle, and starts at -22 LUFS so the
- * pad is felt more than heard.
+ * PR 1 for the spatial world upgrade: no shipped samples, no Tone.js, just six
+ * Web Audio synth layers that behave like short loops and crossfade by the
+ * same phase telemetry the item camera/morph uses. Default is silent; a user
+ * tap is required before an AudioContext exists.
  */
 const STORAGE_KEY = "surfaced.soundscape.enabled";
+const PHASE_EVENT = "surfaced:world-phase";
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+const ROUTE_LAYER_SCALE = 0.72;
 
-// Map alcove kinds to chord roots (Hz) and intervals (semitones)
-const PALETTE: Record<string, { root: number; intervals: number[]; lfoHz: number; lpHz: number }> = {
-  ai:            { root: 220.00, intervals: [0, 7, 14, 19], lfoHz: 0.07, lpHz: 360 },
-  writing:       { root: 174.61, intervals: [0, 5, 9, 12],  lfoHz: 0.05, lpHz: 420 },
-  design:        { root: 261.63, intervals: [0, 4, 7, 11],  lfoHz: 0.09, lpHz: 480 },
-  developer:     { root: 146.83, intervals: [0, 7, 10, 17], lfoHz: 0.06, lpHz: 320 },
-  productivity: { root: 196.00, intervals: [0, 5, 7, 12],  lfoHz: 0.05, lpHz: 380 },
-  research:      { root: 110.00, intervals: [0, 3, 7, 10],  lfoHz: 0.04, lpHz: 300 },
-  audio:         { root: 261.63, intervals: [0, 7, 12, 19], lfoHz: 0.08, lpHz: 500 },
-  finance:       { root: 130.81, intervals: [0, 4, 7, 11],  lfoHz: 0.05, lpHz: 340 },
-  social:        { root: 246.94, intervals: [0, 3, 7, 10],  lfoHz: 0.07, lpHz: 440 },
-  health:        { root: 174.61, intervals: [0, 5, 7, 12],  lfoHz: 0.04, lpHz: 360 },
-  entertainment: { root: 293.66, intervals: [0, 4, 7, 11],  lfoHz: 0.10, lpHz: 520 },
-  default:       { root: 196.00, intervals: [0, 5, 9, 12],  lfoHz: 0.06, lpHz: 400 },
-};
+type OscillatorKind = OscillatorType;
 
-interface ActiveVoice {
-  ctx: AudioContext;
-  out: GainNode;
+interface LayerSpec {
+  intervals: number[];
+  oscillator: OscillatorKind;
+  detuneSpread: number;
+  filterHz: number;
+  filterQ: number;
+  delayMs: number;
+  feedback: number;
+  lfoHz: number;
+  lfoDepth: number;
+  maxGain: number;
+}
+
+interface LayerVoice {
+  gain: GainNode;
+  filter: BiquadFilterNode;
   oscs: OscillatorNode[];
   lfo: OscillatorNode;
-  lp: BiquadFilterNode;
+}
+
+interface ActiveSoundscape {
+  ctx: AudioContext;
+  master: GainNode;
+  layers: LayerVoice[];
+  key: string;
+}
+
+const ROOTS: Record<string, number> = {
+  ai: 220.0,
+  writing: 174.61,
+  design: 261.63,
+  developer: 146.83,
+  productivity: 196.0,
+  research: 110.0,
+  audio: 261.63,
+  finance: 130.81,
+  social: 246.94,
+  health: 174.61,
+  entertainment: 293.66,
+  default: 196.0,
+};
+
+const LAYERS: LayerSpec[] = [
+  // Arrival: sparse sub-bass drone.
+  {
+    intervals: [-24, -12, 0],
+    oscillator: "sine",
+    detuneSpread: 3,
+    filterHz: 150,
+    filterQ: 0.55,
+    delayMs: 0,
+    feedback: 0,
+    lfoHz: 1 / 16,
+    lfoDepth: 28,
+    maxGain: 0.72,
+  },
+  // Recognition: bell-pad layer enters.
+  {
+    intervals: [0, 7, 12, 19],
+    oscillator: "triangle",
+    detuneSpread: 9,
+    filterHz: 520,
+    filterQ: 0.7,
+    delayMs: 180,
+    feedback: 0.18,
+    lfoHz: 1 / 12,
+    lfoDepth: 70,
+    maxGain: 0.58,
+  },
+  // Heart: full harmonic stack.
+  {
+    intervals: [-12, 0, 4, 7, 12, 16],
+    oscillator: "sawtooth",
+    detuneSpread: 14,
+    filterHz: 880,
+    filterQ: 0.85,
+    delayMs: 260,
+    feedback: 0.24,
+    lfoHz: 1 / 10,
+    lfoDepth: 120,
+    maxGain: 0.42,
+  },
+  // Inversion: cooled, reverbed pulse.
+  {
+    intervals: [-12, 0, 3, 10, 15],
+    oscillator: "triangle",
+    detuneSpread: 7,
+    filterHz: 340,
+    filterQ: 1.2,
+    delayMs: 420,
+    feedback: 0.34,
+    lfoHz: 0.75,
+    lfoDepth: 150,
+    maxGain: 0.48,
+  },
+  // Communion: choral pad / constellation.
+  {
+    intervals: [-7, 0, 5, 7, 12, 19],
+    oscillator: "sine",
+    detuneSpread: 18,
+    filterHz: 740,
+    filterQ: 0.65,
+    delayMs: 520,
+    feedback: 0.28,
+    lfoHz: 1 / 14,
+    lfoDepth: 95,
+    maxGain: 0.5,
+  },
+  // Departure: collapses to a single sine.
+  {
+    intervals: [-24],
+    oscillator: "sine",
+    detuneSpread: 0,
+    filterHz: 220,
+    filterQ: 0.45,
+    delayMs: 90,
+    feedback: 0.08,
+    lfoHz: 1 / 16,
+    lfoDepth: 18,
+    maxGain: 0.68,
+  },
+];
+
+function prefersReducedMotion(): boolean {
+  return typeof window !== "undefined" && window.matchMedia?.(REDUCED_MOTION_QUERY).matches === true;
+}
+
+function readScrollT(): number {
+  if (typeof window === "undefined") return 0;
+  const max = Math.max(1, document.documentElement.scrollHeight - window.innerHeight);
+  return clamp01(window.scrollY / max);
+}
+
+function currentWorldSeed(pathname: string | null): WorldSeed {
+  if (typeof document === "undefined") {
+    return deriveWorldSeed({ pathname: pathname || "/" });
+  }
+  const slug = document.body.dataset.itemSlug;
+  const category = document.body.dataset.itemCategory;
+  return deriveWorldSeed({ pathname: pathname || "/", slug, category });
+}
+
+function soundscapeKey(seed: WorldSeed): string {
+  return `${seed.scene}:${seed.key}:${seed.alcove.kind}`;
+}
+
+function note(root: number, semis: number): number {
+  return root * Math.pow(2, semis / 12);
+}
+
+function rootForSeed(seed: WorldSeed): number {
+  const base = ROOTS[seed.alcove.kind] ?? ROOTS.default;
+  return base * (0.96 + seed.hue * 0.08);
+}
+
+function startLayeredSoundscape(seed: WorldSeed): ActiveSoundscape {
+  type AnyWin = Window & typeof globalThis & { webkitAudioContext?: typeof AudioContext };
+  const AC: typeof AudioContext = window.AudioContext ?? (window as AnyWin).webkitAudioContext!;
+  const ctx = new AC({ latencyHint: "interactive" });
+  const master = ctx.createGain();
+  master.gain.value = 0;
+  master.connect(ctx.destination);
+
+  const root = rootForSeed(seed);
+  const layers = LAYERS.map((spec, layerIndex) => createLayer(ctx, master, root, spec, layerIndex, seed));
+  master.gain.setValueAtTime(0, ctx.currentTime);
+  master.gain.linearRampToValueAtTime(0.058, ctx.currentTime + 1.1);
+
+  return { ctx, master, layers, key: soundscapeKey(seed) };
+}
+
+function createLayer(
+  ctx: AudioContext,
+  master: GainNode,
+  root: number,
+  spec: LayerSpec,
+  layerIndex: number,
+  seed: WorldSeed
+): LayerVoice {
+  const gain = ctx.createGain();
+  gain.gain.value = 0;
+  gain.connect(master);
+
+  const filter = ctx.createBiquadFilter();
+  filter.type = layerIndex >= 3 ? "bandpass" : "lowpass";
+  filter.frequency.value = spec.filterHz;
+  filter.Q.value = spec.filterQ;
+
+  if (spec.delayMs > 0) {
+    const delay = ctx.createDelay(1.2);
+    const feedback = ctx.createGain();
+    delay.delayTime.value = spec.delayMs / 1000;
+    feedback.gain.value = spec.feedback;
+    filter.connect(delay);
+    delay.connect(feedback);
+    feedback.connect(delay);
+    delay.connect(gain);
+  }
+  filter.connect(gain);
+
+  const lfo = ctx.createOscillator();
+  const lfoGain = ctx.createGain();
+  lfo.frequency.value = spec.lfoHz;
+  lfoGain.gain.value = spec.lfoDepth;
+  lfo.connect(lfoGain);
+  lfoGain.connect(filter.frequency);
+  lfo.start();
+
+  const oscs = spec.intervals.map((semis, i) => {
+    const osc = ctx.createOscillator();
+    const voiceGain = ctx.createGain();
+    osc.type = spec.oscillator;
+    osc.frequency.value = note(root, semis);
+    osc.detune.value = (i - (spec.intervals.length - 1) / 2) * spec.detuneSpread + (seed.hue - 0.5) * 12;
+    voiceGain.gain.value = 1 / Math.max(1.8, spec.intervals.length);
+    osc.connect(voiceGain);
+    voiceGain.connect(filter);
+    osc.start();
+    return osc;
+  });
+
+  return { gain, filter, oscs, lfo };
+}
+
+function syncLayerGains(active: ActiveSoundscape, telemetry: WorldPhaseTelemetry): void {
+  const now = active.ctx.currentTime;
+  const fromPower = Math.cos(telemetry.mix * Math.PI * 0.5);
+  const toPower = Math.sin(telemetry.mix * Math.PI * 0.5);
+  const routeScale = telemetry.scene === "route" ? ROUTE_LAYER_SCALE : 1;
+  const masterTarget = (0.048 + telemetry.glow * 0.012) * routeScale;
+
+  active.master.gain.setTargetAtTime(masterTarget, now, 0.16);
+
+  active.layers.forEach((layer, index) => {
+    let power = 0;
+    if (index === telemetry.phaseIndex) power = fromPower;
+    if (index === telemetry.nextPhaseIndex) power = Math.max(power, toPower);
+    const target = power * LAYERS[index].maxGain;
+    layer.gain.gain.setTargetAtTime(target, now, 0.085);
+    layer.filter.frequency.setTargetAtTime(
+      LAYERS[index].filterHz * (0.82 + telemetry.glow * 0.22),
+      now,
+      0.18
+    );
+  });
+}
+
+function teardown(active: ActiveSoundscape | null): void {
+  if (!active) return;
+  try {
+    const now = active.ctx.currentTime;
+    active.master.gain.cancelScheduledValues(now);
+    active.master.gain.setValueAtTime(active.master.gain.value, now);
+    active.master.gain.linearRampToValueAtTime(0, now + 0.55);
+    window.setTimeout(() => {
+      try {
+        active.layers.forEach((layer) => {
+          layer.oscs.forEach((osc) => osc.stop());
+          layer.lfo.stop();
+        });
+      } catch {}
+      try {
+        active.ctx.close();
+      } catch {}
+    }, 650);
+  } catch {}
 }
 
 export function AmbientSoundscape() {
   const pathname = usePathname();
   const [enabled, setEnabled] = useState(false);
-  const voiceRef = useRef<ActiveVoice | null>(null);
-  const currentKey = useRef<string>("");
+  const [phaseLabel, setPhaseLabel] = useState("Arrival");
+  const [reducedMotion, setReducedMotion] = useState(false);
+  const voiceRef = useRef<ActiveSoundscape | null>(null);
+  const seedRef = useRef<WorldSeed | null>(null);
+  const telemetryRef = useRef<WorldPhaseTelemetry | null>(null);
+  const rafRef = useRef(0);
+  const labelRef = useRef("Arrival");
 
-  // Restore preference from localStorage
   useEffect(() => {
-    try {
-      if (localStorage.getItem(STORAGE_KEY) === "1") setEnabled(true);
-    } catch {}
+    const syncSeed = () => {
+      const seed = currentWorldSeed(pathname);
+      const key = soundscapeKey(seed);
+      const active = voiceRef.current;
+      seedRef.current = seed;
+
+      if (active && active.key !== key && !prefersReducedMotion()) {
+        teardown(active);
+        voiceRef.current = startLayeredSoundscape(seed);
+      }
+      schedulePhaseSync();
+    };
+
+    syncSeed();
+    window.addEventListener("surfaced:world-reseed", syncSeed);
+    return () => window.removeEventListener("surfaced:world-reseed", syncSeed);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pathname]);
+
+  useEffect(() => {
+    const schedule = () => schedulePhaseSync();
+    window.addEventListener("scroll", schedule, { passive: true });
+    window.addEventListener("resize", schedule, { passive: true });
+    schedule();
+    return () => {
+      window.removeEventListener("scroll", schedule);
+      window.removeEventListener("resize", schedule);
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Persist preference
   useEffect(() => {
-    try {
-      localStorage.setItem(STORAGE_KEY, enabled ? "1" : "0");
-    } catch {}
-  }, [enabled]);
+    const media = window.matchMedia?.(REDUCED_MOTION_QUERY);
+    if (!media) return;
+    const syncReducedMotion = () => {
+      const isReduced = media.matches;
+      setReducedMotion(isReduced);
+      if (isReduced && voiceRef.current) {
+        setEnabled(false);
+        teardown(voiceRef.current);
+        voiceRef.current = null;
+      }
+    };
+    syncReducedMotion();
+    media.addEventListener?.("change", syncReducedMotion);
+    return () => media.removeEventListener?.("change", syncReducedMotion);
+  }, []);
 
-  // Build / switch the chord when alcove changes
-  useEffect(() => {
-    if (!enabled) {
-      teardown();
+  useEffect(() => () => teardown(voiceRef.current), []);
+
+  function schedulePhaseSync() {
+    if (rafRef.current) return;
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = 0;
+      const seed = seedRef.current ?? currentWorldSeed(pathname);
+      const telemetry = getWorldPhaseTelemetry(seed, readScrollT());
+      telemetryRef.current = telemetry;
+      const active = voiceRef.current;
+      if (active) syncLayerGains(active, telemetry);
+      document.body.dataset.worldPhase = telemetry.id;
+      window.dispatchEvent(new CustomEvent(PHASE_EVENT, { detail: telemetry }));
+
+      if (labelRef.current !== telemetry.label) {
+        labelRef.current = telemetry.label;
+        setPhaseLabel(telemetry.label);
+      }
+    });
+  }
+
+  async function toggleSoundscape() {
+    if (enabled) {
+      setEnabled(false);
+      try {
+        localStorage.setItem(STORAGE_KEY, "0");
+      } catch {}
+      teardown(voiceRef.current);
+      voiceRef.current = null;
       return;
     }
-    const seed = deriveWorldSeed({ pathname: pathname || "/" });
-    const key = seed.alcove.kind;
-    if (key === currentKey.current && voiceRef.current) return;
-    currentKey.current = key;
 
-    teardown();
-    voiceRef.current = startVoice(PALETTE[key] || PALETTE.default);
+    if (prefersReducedMotion()) {
+      setPhaseLabel("Motion safe");
+      return;
+    }
 
-    return () => teardown();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [enabled, pathname]);
-
-  function teardown() {
-    const v = voiceRef.current;
-    if (!v) return;
+    const seed = currentWorldSeed(pathname);
+    seedRef.current = seed;
+    const active = startLayeredSoundscape(seed);
+    voiceRef.current = active;
+    if (active.ctx.state === "suspended") {
+      await active.ctx.resume();
+    }
+    const telemetry = getWorldPhaseTelemetry(seed, readScrollT());
+    telemetryRef.current = telemetry;
+    syncLayerGains(active, telemetry);
+    setEnabled(true);
     try {
-      const now = v.ctx.currentTime;
-      v.out.gain.cancelScheduledValues(now);
-      v.out.gain.setValueAtTime(v.out.gain.value, now);
-      v.out.gain.linearRampToValueAtTime(0, now + 0.9);
-      setTimeout(() => {
-        try { v.oscs.forEach((o) => o.stop()); v.lfo.stop(); } catch {}
-        try { v.ctx.close(); } catch {}
-      }, 1000);
+      localStorage.setItem(STORAGE_KEY, "1");
     } catch {}
-    voiceRef.current = null;
+    schedulePhaseSync();
   }
 
-  function startVoice(p: typeof PALETTE.default): ActiveVoice {
-    type AnyWin = Window & typeof globalThis & { webkitAudioContext?: typeof AudioContext };
-    const AC: typeof AudioContext = window.AudioContext ?? (window as AnyWin).webkitAudioContext!;
-    const ctx = new AC();
-    const out = ctx.createGain();
-    out.gain.value = 0;
-    out.connect(ctx.destination);
+  const disabledForMotion = reducedMotion;
+  const label = disabledForMotion
+    ? "Soundscape disabled while reduced motion is enabled"
+    : enabled
+      ? `Mute ${phaseLabel} soundscape`
+      : "Tap to enable scroll-locked soundscape";
 
-    out.gain.cancelScheduledValues(ctx.currentTime);
-    out.gain.setValueAtTime(0, ctx.currentTime);
-    out.gain.linearRampToValueAtTime(0.06, ctx.currentTime + 1.6);
-
-    const lp = ctx.createBiquadFilter();
-    lp.type = "lowpass";
-    lp.frequency.value = p.lpHz;
-    lp.Q.value = 0.7;
-
-    const oscs: OscillatorNode[] = p.intervals.map((semis, i) => {
-      const o = ctx.createOscillator();
-      o.type = i === 0 ? "sine" : i === 1 ? "triangle" : "sine";
-      o.frequency.value = p.root * Math.pow(2, semis / 12);
-      o.detune.value = (i - 1.5) * 6;
-      const g = ctx.createGain();
-      g.gain.value = i === 0 ? 0.7 : 0.45 - i * 0.06;
-      o.connect(g);
-      g.connect(lp);
-      o.start();
-      return o;
-    });
-
-    lp.connect(out);
-
-    const lfo = ctx.createOscillator();
-    const lfoGain = ctx.createGain();
-    lfo.frequency.value = p.lfoHz;
-    lfoGain.gain.value = 90;
-    lfo.connect(lfoGain);
-    lfoGain.connect(lp.frequency);
-    lfo.start();
-
-    return { ctx, out, oscs, lfo, lp };
-  }
-
-  // The toggle UI — fixed bottom-right
   return (
     <button
-      onClick={() => setEnabled((e) => !e)}
+      onClick={toggleSoundscape}
       aria-pressed={enabled}
-      aria-label={enabled ? "Mute ambient soundscape" : "Play ambient soundscape — adapts to each scene"}
-      title={enabled ? "Mute soundscape" : "Play ambient soundscape"}
-      className={`fixed bottom-6 right-6 z-[60] w-12 h-12 rounded-full backdrop-blur-md border transition-all flex items-center justify-center shadow-lg ${
+      aria-label={label}
+      title={label}
+      className={`fixed bottom-6 right-6 z-[60] h-12 rounded-full backdrop-blur-md border transition-all inline-flex items-center justify-center gap-2 px-3 sm:px-4 shadow-lg ${
         enabled
           ? "bg-accent text-white border-accent/40 shadow-[0_8px_30px_rgba(168,85,247,0.4)]"
           : "bg-black/40 text-white/70 border-white/15 hover:bg-black/60 hover:text-white"
       }`}
     >
       {enabled ? (
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
           <path d="M11 5L6 9H2v6h4l5 4V5z" />
           <path d="M19.07 4.93a10 10 0 010 14.14M15.54 8.46a5 5 0 010 7.07" />
         </svg>
       ) : (
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
           <path d="M11 5L6 9H2v6h4l5 4V5z" />
           <line x1="22" y1="9" x2="16" y2="15" />
           <line x1="16" y1="9" x2="22" y2="15" />
         </svg>
       )}
+      <span className="text-xs font-semibold leading-none">
+        {enabled ? phaseLabel : disabledForMotion ? "Motion safe" : "Tap for sound"}
+      </span>
+      <span className="sr-only">
+        {ITEM_KEYFRAMES.map((phase) => phase.label).join(", ")}
+      </span>
     </button>
   );
 }

--- a/src/components/3d/AmbientSoundscape.tsx
+++ b/src/components/3d/AmbientSoundscape.tsx
@@ -50,6 +50,7 @@ interface ActiveSoundscape {
   master: GainNode;
   layers: LayerVoice[];
   key: string;
+  hiddenMuted: boolean;
 }
 
 const ROOTS: Record<string, number> = {
@@ -193,7 +194,7 @@ function startLayeredSoundscape(seed: WorldSeed): ActiveSoundscape {
   master.gain.setValueAtTime(0, ctx.currentTime);
   master.gain.linearRampToValueAtTime(0.058, ctx.currentTime + 1.1);
 
-  return { ctx, master, layers, key: soundscapeKey(seed) };
+  return { ctx, master, layers, key: soundscapeKey(seed), hiddenMuted: document.hidden };
 }
 
 function createLayer(
@@ -254,7 +255,7 @@ function syncLayerGains(active: ActiveSoundscape, telemetry: WorldPhaseTelemetry
   const fromPower = Math.cos(telemetry.mix * Math.PI * 0.5);
   const toPower = Math.sin(telemetry.mix * Math.PI * 0.5);
   const routeScale = telemetry.scene === "route" ? ROUTE_LAYER_SCALE : 1;
-  const masterTarget = (0.048 + telemetry.glow * 0.012) * routeScale;
+  const masterTarget = active.hiddenMuted ? 0 : (0.048 + telemetry.glow * 0.012) * routeScale;
 
   active.master.gain.setTargetAtTime(masterTarget, now, 0.16);
 
@@ -270,6 +271,14 @@ function syncLayerGains(active: ActiveSoundscape, telemetry: WorldPhaseTelemetry
       0.18
     );
   });
+}
+
+function setHiddenMuted(active: ActiveSoundscape | null, hidden: boolean): void {
+  if (!active) return;
+  active.hiddenMuted = hidden;
+  const now = active.ctx.currentTime;
+  active.master.gain.cancelScheduledValues(now);
+  active.master.gain.setTargetAtTime(hidden ? 0 : active.master.gain.value, now, hidden ? 0.04 : 0.12);
 }
 
 function teardown(active: ActiveSoundscape | null): void {
@@ -334,6 +343,17 @@ export function AmbientSoundscape() {
       window.removeEventListener("resize", schedule);
       if (rafRef.current) cancelAnimationFrame(rafRef.current);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const syncVisibility = () => {
+      setHiddenMuted(voiceRef.current, document.hidden);
+      if (!document.hidden) schedulePhaseSync();
+    };
+    syncVisibility();
+    document.addEventListener("visibilitychange", syncVisibility);
+    return () => document.removeEventListener("visibilitychange", syncVisibility);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/components/3d/GlobalWorld.tsx
+++ b/src/components/3d/GlobalWorld.tsx
@@ -124,6 +124,8 @@ export function GlobalWorld() {
     return () => document.removeEventListener("visibilitychange", handler);
   }, []);
 
+  const shouldKeepDepartureAlive = seed.scene === "item" && scrollT > 0.9;
+  const shouldRenderWorld = enabled && !hidden && (inViewport || shouldKeepDepartureAlive);
   const [a, b, c] = seed.alcove.palette;
   const fallback = `radial-gradient(at 28% 20%, ${a}55, transparent 60%), radial-gradient(at 72% 78%, ${b}33, transparent 65%), ${c}`;
 
@@ -133,7 +135,7 @@ export function GlobalWorld() {
       className="fixed inset-0 pointer-events-none -z-10"
       style={{ background: fallback }}
     >
-      {enabled && !hidden && inViewport && (
+      {shouldRenderWorld && (
         <WorldCanvas seed={seed} scrollT={scrollT} pointer={pointer} />
       )}
       {/* Scrim — keeps text readable against the lively backdrop */}

--- a/src/components/3d/WorldCanvas.tsx
+++ b/src/components/3d/WorldCanvas.tsx
@@ -5,6 +5,13 @@ import { Canvas, useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 import type { WorldSeed } from "@/lib/world-seed";
 import { makeRng } from "@/lib/world-seed";
+import {
+  ITEM_KEYFRAMES,
+  clamp01,
+  getItemPhase,
+  getItemSceneSnapshot,
+  lerp,
+} from "@/lib/world-phase";
 
 interface Props {
   seed: WorldSeed;
@@ -12,134 +19,7 @@ interface Props {
   pointer: { x: number; y: number };
 }
 
-type ItemKeyframe = {
-  camera: [number, number, number];
-  lookAt: [number, number, number];
-  fov: number;
-  density: number;
-  objectScale: number;
-  objectY: number;
-  objectZ: number;
-  twist: number;
-  glow: number;
-};
-
-const ITEM_KEYFRAMES: ItemKeyframe[] = [
-  {
-    camera: [0, 0.15, 6.25],
-    lookAt: [0, -0.35, -2.1],
-    fov: 66,
-    density: 0.58,
-    objectScale: 1.0,
-    objectY: -0.42,
-    objectZ: -2.05,
-    twist: 0.22,
-    glow: 0.72,
-  },
-  {
-    camera: [0.95, 0.55, 5.45],
-    lookAt: [0.1, -0.2, -2.7],
-    fov: 61,
-    density: 0.86,
-    objectScale: 1.18,
-    objectY: -0.18,
-    objectZ: -2.65,
-    twist: 0.58,
-    glow: 0.9,
-  },
-  {
-    camera: [-1.15, 0.85, 4.75],
-    lookAt: [-0.1, -0.05, -3.25],
-    fov: 57,
-    density: 1.0,
-    objectScale: 0.92,
-    objectY: -0.02,
-    objectZ: -3.2,
-    twist: 1.08,
-    glow: 1.15,
-  },
-  {
-    camera: [1.35, -0.05, 4.2],
-    lookAt: [0, -0.18, -3.95],
-    fov: 54,
-    density: 0.74,
-    objectScale: 1.34,
-    objectY: -0.28,
-    objectZ: -3.85,
-    twist: 0.72,
-    glow: 0.96,
-  },
-  {
-    camera: [-0.55, 0.35, 3.72],
-    lookAt: [0.08, -0.32, -4.6],
-    fov: 50,
-    density: 0.96,
-    objectScale: 1.12,
-    objectY: -0.46,
-    objectZ: -4.45,
-    twist: 1.38,
-    glow: 1.22,
-  },
-  {
-    camera: [0.15, 0.08, 5.15],
-    lookAt: [0, -0.55, -5.05],
-    fov: 59,
-    density: 0.64,
-    objectScale: 0.82,
-    objectY: -0.62,
-    objectZ: -5.05,
-    twist: 0.36,
-    glow: 0.66,
-  },
-];
-
 const ITEM_MORPH_STOPS = ITEM_KEYFRAMES.length;
-
-function clamp01(value: number): number {
-  return Math.min(1, Math.max(0, value));
-}
-
-function smoothstep(value: number): number {
-  return value * value * (3 - 2 * value);
-}
-
-function lerp(a: number, b: number, t: number): number {
-  return a + (b - a) * t;
-}
-
-function getItemPhase(scrollT: number) {
-  const scaled = clamp01(scrollT) * (ITEM_MORPH_STOPS - 1);
-  const index = Math.min(ITEM_MORPH_STOPS - 2, Math.floor(scaled));
-  const next = Math.min(ITEM_MORPH_STOPS - 1, index + 1);
-  return { index, next, t: smoothstep(scaled - index), raw: scaled };
-}
-
-function getItemSceneSnapshot(seed: WorldSeed, scrollT: number) {
-  const phase = getItemPhase(scrollT);
-  const from = ITEM_KEYFRAMES[phase.index];
-  const to = ITEM_KEYFRAMES[phase.next];
-  const side = seed.rngSeed % 2 === 0 ? 1 : -1;
-  const depth = 0.9 + seed.intensity * 0.18;
-  const cameraX = lerp(from.camera[0], to.camera[0], phase.t) * side;
-  const lookX = lerp(from.lookAt[0], to.lookAt[0], phase.t) * side * 0.45;
-  const heartbeat = 0.92 + Math.sin(phase.raw * Math.PI) * 0.08;
-
-  return {
-    cameraX,
-    cameraY: lerp(from.camera[1], to.camera[1], phase.t),
-    cameraZ: lerp(from.camera[2], to.camera[2], phase.t) * depth,
-    lookX,
-    lookY: lerp(from.lookAt[1], to.lookAt[1], phase.t),
-    lookZ: lerp(from.lookAt[2], to.lookAt[2], phase.t),
-    fov: lerp(from.fov, to.fov, phase.t),
-    density: lerp(from.density, to.density, phase.t) * heartbeat,
-    objectScale: lerp(from.objectScale, to.objectScale, phase.t),
-    objectY: lerp(from.objectY, to.objectY, phase.t),
-    objectZ: lerp(from.objectZ, to.objectZ, phase.t),
-    twist: lerp(from.twist, to.twist, phase.t),
-    glow: lerp(from.glow, to.glow, phase.t),
-  };
-}
 
 function signedNoise(seed: number, vertexIndex: number, channel: number): number {
   const n = Math.sin((seed * 0.0001 + vertexIndex * 12.9898 + channel * 78.233) * 437.585);

--- a/src/components/ui/TiltCard.tsx
+++ b/src/components/ui/TiltCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, MouseEvent } from "react";
+import { useEffect, useRef, type PointerEvent } from "react";
 
 interface TiltCardProps {
   children: React.ReactNode;
@@ -18,35 +18,96 @@ interface TiltCardProps {
  */
 export function TiltCard({ children, className = "", maxTilt = 8, glowColor }: TiltCardProps) {
   const ref = useRef<HTMLDivElement>(null);
+  const rafRef = useRef<number | null>(null);
+  const pointerRef = useRef<{ x: number; y: number } | null>(null);
+  const cleanupExitWatchRef = useRef<(() => void) | null>(null);
 
-  function handleMouseMove(e: MouseEvent<HTMLDivElement>) {
+  useEffect(() => () => {
+    if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    cleanupExitWatchRef.current?.();
+  }, []);
+
+  function canTilt() {
+    if (typeof window === "undefined") return false;
+    if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return false;
+    if (window.matchMedia?.("(pointer: coarse)").matches) return false;
+    return true;
+  }
+
+  function resetCard() {
     const card = ref.current;
     if (!card) return;
+    if (rafRef.current) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+    pointerRef.current = null;
+    card.style.transform = "perspective(800px) rotateX(0deg) rotateY(0deg) scale3d(1,1,1)";
+    card.style.boxShadow = "";
+    cleanupExitWatchRef.current?.();
+    cleanupExitWatchRef.current = null;
+  }
+
+  function watchForExit() {
+    if (cleanupExitWatchRef.current) return;
+
+    const resetIfOutside = (event: globalThis.PointerEvent) => {
+      const card = ref.current;
+      if (!card) return;
+      const rect = card.getBoundingClientRect();
+      const outside =
+        event.clientX < rect.left ||
+        event.clientX > rect.right ||
+        event.clientY < rect.top ||
+        event.clientY > rect.bottom;
+      if (outside) resetCard();
+    };
+
+    document.addEventListener("pointermove", resetIfOutside, { passive: true });
+    window.addEventListener("scroll", resetCard, { passive: true });
+    window.addEventListener("blur", resetCard);
+
+    cleanupExitWatchRef.current = () => {
+      document.removeEventListener("pointermove", resetIfOutside);
+      window.removeEventListener("scroll", resetCard);
+      window.removeEventListener("blur", resetCard);
+    };
+  }
+
+  function applyTilt() {
+    rafRef.current = null;
+    const card = ref.current;
+    const pointer = pointerRef.current;
+    if (!card || !pointer) return;
+
     const rect = card.getBoundingClientRect();
-    const x = e.clientX - rect.left;
-    const y = e.clientY - rect.top;
+    const x = pointer.x - rect.left;
+    const y = pointer.y - rect.top;
     const cx = rect.width / 2;
     const cy = rect.height / 2;
     const rotateX = ((y - cy) / cy) * -maxTilt;
     const rotateY = ((x - cx) / cx) * maxTilt;
     card.style.transform = `perspective(800px) rotateX(${rotateX}deg) rotateY(${rotateY}deg) scale3d(1.02,1.02,1.02)`;
-    if (glowColor) {
-      card.style.boxShadow = glowColor;
-    }
+    if (glowColor) card.style.boxShadow = glowColor;
   }
 
-  function handleMouseLeave() {
-    const card = ref.current;
-    if (!card) return;
-    card.style.transform = "perspective(800px) rotateX(0deg) rotateY(0deg) scale3d(1,1,1)";
-    card.style.boxShadow = "";
+  function handlePointerMove(e: PointerEvent<HTMLDivElement>) {
+    if (!canTilt()) {
+      resetCard();
+      return;
+    }
+    pointerRef.current = { x: e.clientX, y: e.clientY };
+    watchForExit();
+    if (!rafRef.current) rafRef.current = requestAnimationFrame(applyTilt);
   }
 
   return (
     <div
       ref={ref}
-      onMouseMove={handleMouseMove}
-      onMouseLeave={handleMouseLeave}
+      onPointerMove={handlePointerMove}
+      onPointerLeave={resetCard}
+      onPointerCancel={resetCard}
+      onBlur={resetCard}
       className={`will-change-transform ${className}`}
       style={{ transition: "transform 0.15s ease-out, box-shadow 0.15s ease-out" }}
     >

--- a/src/lib/world-phase.ts
+++ b/src/lib/world-phase.ts
@@ -1,0 +1,223 @@
+import type { WorldSeed } from "@/lib/world-seed";
+
+export type WorldAlcoveId =
+  | "arrival"
+  | "recognition"
+  | "heart"
+  | "inversion"
+  | "communion"
+  | "departure";
+
+export interface ItemKeyframe {
+  id: WorldAlcoveId;
+  label: string;
+  camera: [number, number, number];
+  lookAt: [number, number, number];
+  fov: number;
+  density: number;
+  objectScale: number;
+  objectY: number;
+  objectZ: number;
+  twist: number;
+  glow: number;
+}
+
+export interface ItemPhase {
+  index: number;
+  next: number;
+  t: number;
+  raw: number;
+}
+
+export interface WorldPhaseTelemetry {
+  scene: WorldSeed["scene"];
+  scrollT: number;
+  phaseIndex: number;
+  nextPhaseIndex: number;
+  mix: number;
+  raw: number;
+  id: WorldAlcoveId;
+  nextId: WorldAlcoveId;
+  label: string;
+  nextLabel: string;
+  cameraX: number;
+  cameraY: number;
+  cameraZ: number;
+  lookX: number;
+  lookY: number;
+  lookZ: number;
+  fov: number;
+  density: number;
+  objectScale: number;
+  objectY: number;
+  objectZ: number;
+  twist: number;
+  glow: number;
+}
+
+export const ITEM_KEYFRAMES: ItemKeyframe[] = [
+  {
+    id: "arrival",
+    label: "Arrival",
+    camera: [0, 0.15, 6.25],
+    lookAt: [0, -0.35, -2.1],
+    fov: 66,
+    density: 0.58,
+    objectScale: 1.0,
+    objectY: -0.42,
+    objectZ: -2.05,
+    twist: 0.22,
+    glow: 0.72,
+  },
+  {
+    id: "recognition",
+    label: "Recognition",
+    camera: [0.95, 0.55, 5.45],
+    lookAt: [0.1, -0.2, -2.7],
+    fov: 61,
+    density: 0.86,
+    objectScale: 1.18,
+    objectY: -0.18,
+    objectZ: -2.65,
+    twist: 0.58,
+    glow: 0.9,
+  },
+  {
+    id: "heart",
+    label: "Heart",
+    camera: [-1.15, 0.85, 4.75],
+    lookAt: [-0.1, -0.05, -3.25],
+    fov: 57,
+    density: 1.0,
+    objectScale: 0.92,
+    objectY: -0.02,
+    objectZ: -3.2,
+    twist: 1.08,
+    glow: 1.15,
+  },
+  {
+    id: "inversion",
+    label: "Inversion",
+    camera: [1.35, -0.05, 4.2],
+    lookAt: [0, -0.18, -3.95],
+    fov: 54,
+    density: 0.74,
+    objectScale: 1.34,
+    objectY: -0.28,
+    objectZ: -3.85,
+    twist: 0.72,
+    glow: 0.96,
+  },
+  {
+    id: "communion",
+    label: "Communion",
+    camera: [-0.55, 0.35, 3.72],
+    lookAt: [0.08, -0.32, -4.6],
+    fov: 50,
+    density: 0.96,
+    objectScale: 1.12,
+    objectY: -0.46,
+    objectZ: -4.45,
+    twist: 1.38,
+    glow: 1.22,
+  },
+  {
+    id: "departure",
+    label: "Departure",
+    camera: [0.15, 0.08, 5.15],
+    lookAt: [0, -0.55, -5.05],
+    fov: 59,
+    density: 0.64,
+    objectScale: 0.82,
+    objectY: -0.62,
+    objectZ: -5.05,
+    twist: 0.36,
+    glow: 0.66,
+  },
+];
+
+const ROUTE_PHASE_STOPS = [0, 2, 5] as const;
+
+export function clamp01(value: number): number {
+  return Math.min(1, Math.max(0, value));
+}
+
+export function smoothstep(value: number): number {
+  return value * value * (3 - 2 * value);
+}
+
+export function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+export function getItemPhase(scrollT: number): ItemPhase {
+  const scaled = clamp01(scrollT) * (ITEM_KEYFRAMES.length - 1);
+  const index = Math.min(ITEM_KEYFRAMES.length - 2, Math.floor(scaled));
+  const next = Math.min(ITEM_KEYFRAMES.length - 1, index + 1);
+  return { index, next, t: smoothstep(scaled - index), raw: scaled };
+}
+
+function getRoutePhase(scrollT: number): ItemPhase {
+  const scaled = clamp01(scrollT) * (ROUTE_PHASE_STOPS.length - 1);
+  const routeIndex = Math.min(ROUTE_PHASE_STOPS.length - 2, Math.floor(scaled));
+  const routeNext = Math.min(ROUTE_PHASE_STOPS.length - 1, routeIndex + 1);
+  return {
+    index: ROUTE_PHASE_STOPS[routeIndex],
+    next: ROUTE_PHASE_STOPS[routeNext],
+    t: smoothstep(scaled - routeIndex),
+    raw: scaled,
+  };
+}
+
+export function getWorldPhase(seed: WorldSeed, scrollT: number): ItemPhase {
+  return seed.scene === "item" ? getItemPhase(scrollT) : getRoutePhase(scrollT);
+}
+
+export function getItemSceneSnapshot(seed: WorldSeed, scrollT: number): WorldPhaseTelemetry {
+  const phase = getItemPhase(scrollT);
+  return buildTelemetry(seed, scrollT, phase);
+}
+
+export function getWorldPhaseTelemetry(seed: WorldSeed, scrollT: number): WorldPhaseTelemetry {
+  return buildTelemetry(seed, scrollT, getWorldPhase(seed, scrollT));
+}
+
+function buildTelemetry(
+  seed: WorldSeed,
+  scrollT: number,
+  phase: ItemPhase
+): WorldPhaseTelemetry {
+  const from = ITEM_KEYFRAMES[phase.index];
+  const to = ITEM_KEYFRAMES[phase.next];
+  const side = seed.rngSeed % 2 === 0 ? 1 : -1;
+  const depth = 0.9 + seed.intensity * 0.18;
+  const cameraX = lerp(from.camera[0], to.camera[0], phase.t) * side;
+  const lookX = lerp(from.lookAt[0], to.lookAt[0], phase.t) * side * 0.45;
+  const heartbeat = 0.92 + Math.sin(phase.raw * Math.PI) * 0.08;
+
+  return {
+    scene: seed.scene,
+    scrollT: clamp01(scrollT),
+    phaseIndex: phase.index,
+    nextPhaseIndex: phase.next,
+    mix: phase.t,
+    raw: phase.raw,
+    id: from.id,
+    nextId: to.id,
+    label: seed.scene === "route" && phase.index === 2 ? "Exploration" : from.label,
+    nextLabel: seed.scene === "route" && phase.next === 2 ? "Exploration" : to.label,
+    cameraX,
+    cameraY: lerp(from.camera[1], to.camera[1], phase.t),
+    cameraZ: lerp(from.camera[2], to.camera[2], phase.t) * depth,
+    lookX,
+    lookY: lerp(from.lookAt[1], to.lookAt[1], phase.t),
+    lookZ: lerp(from.lookAt[2], to.lookAt[2], phase.t),
+    fov: lerp(from.fov, to.fov, phase.t),
+    density: lerp(from.density, to.density, phase.t) * heartbeat,
+    objectScale: lerp(from.objectScale, to.objectScale, phase.t),
+    objectY: lerp(from.objectY, to.objectY, phase.t),
+    objectZ: lerp(from.objectZ, to.objectZ, phase.t),
+    twist: lerp(from.twist, to.twist, phase.t),
+    glow: lerp(from.glow, to.glow, phase.t),
+  };
+}


### PR DESCRIPTION
## Summary
- Adds shared `world-phase` telemetry so the canvas, audio engine, and upcoming post-fx pass read the same deterministic six-alcove scroll state.
- Replaces the old single ambient chord with six raw Web Audio synth layers, crossfaded with equal-power curves by `getWorldPhaseTelemetry()`.
- Keeps sound default-muted and user-gesture gated; reduced-motion tears down active voices and leaves the affordance in a motion-safe state.
- Compresses route pages into an arrival → exploration → departure arc using the same engine, with zero shipped audio samples or Tone.js.

## Notes for reviewers
- Stacked on #95 (`codex/item-scroll-world`) while that PR is still open, so this diff only contains PR 1 audio/telemetry work; retarget to `main` after #95 lands.
- Item scenes stay deterministic from the per-slug `WorldSeed`; `AmbientSoundscape` reads the same body dataset + `surfaced:world-reseed` path as `GlobalWorld`.
- The item arc is still six keyframes: Arrival, Recognition, Heart, Inversion, Communion, Departure.
- Route pages use the compressed 3-phase path by mapping route scroll stops to the item keyframes `[arrival, heart/exploration, departure]`.
- Phase telemetry is exposed through `window` event `surfaced:world-phase` and `body[data-world-phase]` for PR 2 postprocessing integration.

## Test plan
- [x] `npx eslint src/components/3d/AmbientSoundscape.tsx src/components/3d/WorldCanvas.tsx src/lib/world-phase.ts`
- [x] `npm run build` — 3,067 HTML pages; 0 errors; only the pre-existing SEO title-length warnings.
- [x] `npm run audit:adsense` — 0 thin pages / 0 duplicate groups / live tools+gems missing outbound URLs: 0; archive outbound URL warnings remain pre-existing.
- [x] Static browser smoke at `/item/focusmate-virtual-coworking-accountability-partner`: default muted, tap enables soundscape, scroll updates Arrival → Inversion, canvas remains mounted.
- [x] Static browser smoke item → `/tools` client nav: item slug clears and compressed route arc updates to Exploration while sound remains active.
- [x] Lighthouse mobile performance on the item page: 75. `out/` file count: 3,155 files, under the Cloudflare 20,000-file cap.

## Known residual risks
- This PR intentionally ships oscillator-based loops instead of audio samples, so the sample budget is 0KB; browser/device synth timbre may vary slightly.
- Hard reloads remain muted even when the previous session enabled audio, which preserves browser autoplay compliance but means the stored preference is not auto-played.
- Existing Three.js `THREE.Clock` deprecation warnings can still appear in browser logs; this PR does not touch the R3F/Three runtime.
- Static-export smoke with a generic static server can show stripped `__next._tree.txt` prefetch 404s, matching the existing postbuild RSC-sidecar stripping behavior.
