### PR TITLE
Spline-Omma depth: polish + sticky chapters + perf

### DIFF
--- a/src/app/collections/[slug]/page.tsx
+++ b/src/app/collections/[slug]/page.tsx
@@ -15,6 +15,7 @@ import { collectionPageLd, breadcrumbLd, ldScript } from "@/lib/jsonld";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
+import { TiltCard3D } from "@/components/ui/TiltCard3D";
 
 type Props = { params: Promise<{ slug: string }> };
 
@@ -58,7 +59,7 @@ export default async function CollectionPage({ params }: Props) {
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={ldScript(collectionLd)} />
       <script type="application/ld+json" dangerouslySetInnerHTML={ldScript(crumbsLd)} />
-      <section className="relative py-24 sm:py-32 overflow-hidden">
+      <section className="depth-scene relative py-24 sm:py-32 overflow-hidden">
         <div className="absolute inset-0 pointer-events-none">
           <div className="absolute -top-32 left-1/4 w-[480px] h-[480px] rounded-full bg-accent/6 blur-[120px]" />
         </div>
@@ -85,14 +86,14 @@ export default async function CollectionPage({ params }: Props) {
       </section>
 
       <section className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 pb-24">
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
+        <div className="depth-grid grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
           {items.map((item) => (
+            <TiltCard3D key={item.slug} className="rounded-2xl h-full" tiltDepth="medium" maxTilt={14} glowColor="168, 85, 247">
             <Link
-              key={item.slug}
               href={`/item/${item.slug}`}
               className="group block rounded-2xl border border-border/60 bg-surface card-hover-glow transition-all h-full overflow-hidden"
             >
-              <div className="overflow-hidden">
+              <div className="depth-layer-1 overflow-hidden">
                 <ItemImage
                   slug={item.slug}
                   alt={getItemTitle(item)}
@@ -103,14 +104,14 @@ export default async function CollectionPage({ params }: Props) {
                 />
               </div>
               <div className="p-5">
-                <div className="flex items-start justify-between gap-2 mb-3">
+                <div className="depth-layer-3 flex items-start justify-between gap-2 mb-3">
                   <CategoryBadge
                     label={getCategoryLabel(item.type)}
                     color={getCategoryColor(item.type)}
                   />
                   <BookmarkButton slug={item.slug} />
                 </div>
-                <h3 className="text-sm font-semibold text-foreground group-hover:text-accent transition-colors line-clamp-2 mb-1">
+                <h3 className="depth-layer-2 text-sm font-semibold text-foreground group-hover:text-accent transition-colors line-clamp-2 mb-1">
                   {getItemTitle(item)}
                 </h3>
                 <p className="text-xs text-muted-foreground line-clamp-2">
@@ -118,6 +119,7 @@ export default async function CollectionPage({ params }: Props) {
                 </p>
               </div>
             </Link>
+            </TiltCard3D>
           ))}
         </div>
 

--- a/src/app/collections/page.tsx
+++ b/src/app/collections/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import type { Metadata } from "next";
 import { buildMetadata } from "@/lib/seo";
 import { itemListLd, ldScript } from "@/lib/jsonld";
+import { TiltCard3D } from "@/components/ui/TiltCard3D";
 
 export const metadata: Metadata = buildMetadata({
   title: "Collections",
@@ -24,7 +25,7 @@ export default function CollectionsPage() {
   return (
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={ldScript(listLd)} />
-      <section className="relative py-24 sm:py-32 overflow-hidden">
+      <section className="depth-scene relative py-24 sm:py-32 overflow-hidden">
         <div className="absolute inset-0 pointer-events-none">
           <div className="absolute -top-32 left-1/4 w-[480px] h-[480px] rounded-full bg-accent/8 blur-[120px]" />
         </div>
@@ -42,23 +43,23 @@ export default function CollectionsPage() {
       </section>
 
       <section className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 pb-24">
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        <div className="depth-grid grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
           {collections_data.map((col) => (
+            <TiltCard3D key={col.slug} className="rounded-2xl h-full" tiltDepth="medium" maxTilt={14} glowColor="168, 85, 247">
             <Link
-              key={col.slug}
               href={`/collections/${col.slug}`}
               className="group relative rounded-2xl border border-border/60 bg-surface p-8 hover:border-accent/30 card-hover-glow transition-all flex flex-col gap-4"
             >
-              <span className="text-4xl">{col.emoji}</span>
+              <span className="depth-layer-3 text-4xl">{col.emoji}</span>
               <div>
-                <h2 className="text-xl font-bold text-foreground group-hover:text-accent transition-colors mb-2">
+                <h2 className="depth-layer-2 text-xl font-bold text-foreground group-hover:text-accent transition-colors mb-2">
                   {col.title}
                 </h2>
                 <p className="text-sm text-muted-foreground leading-relaxed">
                   {col.description}
                 </p>
               </div>
-              <div className="mt-auto flex items-center justify-between">
+              <div className="depth-layer-4 mt-auto flex items-center justify-between">
                 <span className="text-xs text-muted-foreground">
                   {col.itemSlugs.length} items
                 </span>
@@ -67,6 +68,7 @@ export default function CollectionsPage() {
                 </span>
               </div>
             </Link>
+            </TiltCard3D>
           ))}
         </div>
       </section>

--- a/src/app/discover/page.tsx
+++ b/src/app/discover/page.tsx
@@ -59,11 +59,11 @@ export default function DiscoverArchivePage() {
             Showing the {items.length} most-recent of {(archiveData as AnyItem[]).filter((i) => i.type === "discovery").length} archived discoveries.
           </p>
           <div className="depth-grid grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-            {items.map((item) => (
+            {items.map((item, index) => (
               <TiltCard3D key={item.slug} className="rounded-2xl h-full" tiltDepth="medium" maxTilt={14} glowColor="34, 211, 238">
               <Link href={`/item/${item.slug}`} className="group block rounded-2xl border border-border bg-card overflow-hidden hover:border-accent/40 transition-all h-full">
                 <div className="depth-layer-1 aspect-[16/10] overflow-hidden">
-                  <ItemImage slug={item.slug} alt={getItemTitle(item)} aspectRatio="16/10" width={500} height={313} className="group-hover:scale-[1.03] transition-transform duration-500" />
+                  <ItemImage slug={item.slug} alt={getItemTitle(item)} aspectRatio="16/10" width={500} height={313} className={`${index === 0 ? "hero-zoom-out " : ""}group-hover:scale-[1.03] transition-transform duration-500`} />
                 </div>
                 <div className="p-5">
                   <p className="depth-layer-3 text-[10px] uppercase tracking-wider text-muted-foreground mb-2">Discovery</p>

--- a/src/app/discover/page.tsx
+++ b/src/app/discover/page.tsx
@@ -6,6 +6,7 @@ import { type AnyItem, getItemTitle, getItemExcerpt } from "@/lib/data";
 import { ItemImage } from "@/components/ui/ItemImage";
 import { alcoveByKind } from "@/lib/alcoves";
 import { AlcoveBackdrop } from "@/components/3d/AlcoveBackdrop";
+import { TiltCard3D } from "@/components/ui/TiltCard3D";
 
 export const metadata: Metadata = buildMetadata({
   title: "Discoveries — Archive",
@@ -22,7 +23,7 @@ export default function DiscoverArchivePage() {
 
   return (
     <article>
-      <section className="relative min-h-[55vh] flex items-center overflow-hidden">
+      <section className="depth-scene relative min-h-[55vh] flex items-center overflow-hidden">
         <AlcoveBackdrop alcove={alcoveByKind("research")} trackScroll />
         <div className="relative z-10 max-w-3xl mx-auto px-4 sm:px-6 py-24 sm:py-32">
           <p className="text-xs uppercase tracking-[0.22em] text-white/70 font-semibold mb-4">
@@ -57,18 +58,20 @@ export default function DiscoverArchivePage() {
           <p className="text-sm text-muted-foreground mb-8">
             Showing the {items.length} most-recent of {(archiveData as AnyItem[]).filter((i) => i.type === "discovery").length} archived discoveries.
           </p>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          <div className="depth-grid grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
             {items.map((item) => (
-              <Link key={item.slug} href={`/item/${item.slug}`} className="group block rounded-2xl border border-border bg-card overflow-hidden hover:border-accent/40 transition-all">
-                <div className="aspect-[16/10] overflow-hidden">
+              <TiltCard3D key={item.slug} className="rounded-2xl h-full" tiltDepth="medium" maxTilt={14} glowColor="34, 211, 238">
+              <Link href={`/item/${item.slug}`} className="group block rounded-2xl border border-border bg-card overflow-hidden hover:border-accent/40 transition-all h-full">
+                <div className="depth-layer-1 aspect-[16/10] overflow-hidden">
                   <ItemImage slug={item.slug} alt={getItemTitle(item)} aspectRatio="16/10" width={500} height={313} className="group-hover:scale-[1.03] transition-transform duration-500" />
                 </div>
                 <div className="p-5">
-                  <p className="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">Discovery</p>
-                  <h3 className="text-base font-semibold leading-snug group-hover:text-accent transition-colors line-clamp-2">{getItemTitle(item)}</h3>
+                  <p className="depth-layer-3 text-[10px] uppercase tracking-wider text-muted-foreground mb-2">Discovery</p>
+                  <h3 className="depth-layer-2 text-base font-semibold leading-snug group-hover:text-accent transition-colors line-clamp-2">{getItemTitle(item)}</h3>
                   <p className="mt-2 text-sm text-muted-foreground line-clamp-2 leading-relaxed">{getItemExcerpt(item, 140)}</p>
                 </div>
               </Link>
+              </TiltCard3D>
             ))}
           </div>
         </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -583,9 +583,12 @@ body.has-3d-world .bg-background {
 }
 
 .depth-scene {
+  --section-exit-t: 0;
   perspective: 1800px;
   perspective-origin: 50% 30%;
   transform-style: preserve-3d;
+  filter: blur(calc(var(--section-exit-t, 0) * 6px));
+  transition: filter 0.18s linear;
 }
 
 .chapter-pin {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -612,6 +612,12 @@ body.has-3d-world .bg-background {
   will-change: transform;
 }
 
+.footer-depth-pop {
+  transform: translate3d(0, calc((1 - clamp(0, (var(--scroll-t, 0) - 0.95) * 20, 1)) * 60px), 0);
+  transition: transform 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+  will-change: transform;
+}
+
 .depth-layer-1,
 .depth-layer-2,
 .depth-layer-3,
@@ -1186,6 +1192,10 @@ body.depth-mode .floating-item {
     transform: none !important;
   }
 
+  .footer-depth-pop {
+    transform: none !important;
+  }
+
   .aurora-fallback-blob {
     display: block;
   }
@@ -1225,6 +1235,10 @@ body.depth-mode .floating-item {
   }
 
   .hero-zoom-out {
+    transform: none !important;
+  }
+
+  .footer-depth-pop {
     transform: none !important;
   }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -606,13 +606,11 @@ body.has-3d-world .bg-background {
   --neighbor-tilt-y: 0deg;
   position: relative;
   transform-style: preserve-3d;
-  perspective: 1100px;
   transition:
     transform 0.7s cubic-bezier(0.34, 1.56, 0.64, 1),
     box-shadow 0.35s ease,
     filter 0.35s ease;
   transform:
-    perspective(1100px)
     translate3d(0, var(--rest-y, 0px), 0)
     translateZ(var(--lift-z, 0px))
     rotateX(var(--tilt-x, 0deg))

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -659,6 +659,21 @@ body.has-3d-world .bg-background {
   mix-blend-mode: difference;
 }
 
+.tilt-3d:focus-within {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+  box-shadow:
+    0 0 0 1px rgba(var(--glow-color, 168, 85, 247), 0.35),
+    0 25px 50px -20px rgba(0, 0, 0, 0.55);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tilt-3d:focus-within {
+    outline: 2px solid var(--accent);
+    outline-offset: 4px;
+  }
+}
+
 .rim-light::before,
 .specular-highlight::after {
   content: "";

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -751,7 +751,11 @@ body.has-3d-world .bg-background {
   opacity: 1;
 }
 
-.tilt-3d > * {
+.tilt-3d > .depth-layer-1,
+.tilt-3d > .depth-layer-2,
+.tilt-3d > .depth-layer-3,
+.tilt-3d > .depth-layer-4,
+.tilt-3d > .tilt-3d-pop {
   position: relative;
   z-index: 3;
   transform-style: preserve-3d;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -630,6 +630,35 @@ body.has-3d-world .bg-background {
   transition-duration: 0.22s, 0.35s, 0.35s;
 }
 
+[data-theme="light"] .specular-highlight::after {
+  background: radial-gradient(circle 240px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255,255,255,0.55), transparent 60%);
+  mix-blend-mode: screen;
+}
+
+[data-theme="light"] .rim-light::before {
+  background:
+    conic-gradient(
+      from var(--rim-angle, 0deg) at var(--mouse-x, 50%) var(--mouse-y, 50%),
+      transparent 0deg,
+      rgba(255, 255, 255, 0.85) 28deg,
+      rgba(var(--glow-color, 168, 85, 247), 0.55) 58deg,
+      transparent 118deg,
+      transparent 360deg
+    );
+}
+
+[data-theme="light"] .tilt-3d.is-hovered {
+  box-shadow:
+    0 0 0 1px rgba(var(--glow-color, 168, 85, 247), 0.28),
+    0 30px 60px -22px rgba(0, 0, 0, 0.22),
+    0 35px 80px -28px rgba(var(--glow-color, 168, 85, 247), 0.32);
+}
+
+[data-theme="light"] .companion-orb {
+  background: rgba(20, 20, 28, 0.85);
+  mix-blend-mode: difference;
+}
+
 .rim-light::before,
 .specular-highlight::after {
   content: "";

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,11 @@
 @import "tailwindcss";
 
+@property --rest-y {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 0px;
+}
+
 /* Custom variant for theme switching — use as `light:bg-...` */
 @custom-variant light (&:where([data-theme="light"], [data-theme="light"] *));
 
@@ -100,6 +106,11 @@
   --shadow-drop: rgba(0, 0, 0, 0.5);
   --shadow-drop-light: rgba(0, 0, 0, 0.4);
   --noise-opacity: 0.018;
+  --scroll-t: 0;
+  --scroll-vel: 0;
+  --scroll-tilt: 0deg;
+  --pointer-x: 0;
+  --pointer-y: 0;
 }
 
 [data-theme="light"] {
@@ -182,6 +193,11 @@
   50% { transform: scale(1.05); opacity: 0.8; }
 }
 
+@keyframes depth-rest {
+  0%, 100% { --rest-y: 0px; }
+  50% { --rest-y: 0.5px; }
+}
+
 @keyframes spin-slow {
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }
@@ -211,6 +227,14 @@ body {
   transition: background-color 0.25s ease, color 0.25s ease;
   /* Slight letter-spacing tightening at large sizes — feels more editorial */
   font-feature-settings: "ss01", "cv11";
+}
+
+#main-content {
+  transform: rotateX(var(--scroll-tilt, 0deg));
+  transform-origin: 50% 18vh;
+  transform-style: preserve-3d;
+  transition: transform 0.3s cubic-bezier(0.2, 0.9, 0.3, 1);
+  will-change: transform;
 }
 
 /* Display headings get tighter tracking + optical balance */
@@ -418,6 +442,10 @@ body.has-3d-world .bg-background {
   background: linear-gradient(180deg, rgba(250,250,247,0.65) 0%, rgba(250,250,247,0.45) 30%, rgba(250,250,247,0.75) 100%);
 }
 
+.aurora-fallback-blob {
+  display: none;
+}
+
 /* Floating glass — replaces opaque .bg-card on most cards so the world peeks through */
 .floating-glass {
   background: rgba(15, 15, 20, 0.62);
@@ -447,7 +475,9 @@ body.has-3d-world .bg-background {
    CURSOR COMPANION — fuse.kiwi-style follower
    ============================================ */
 .companion-orb,
-.companion-trail {
+.companion-trail,
+.companion-shadow,
+.companion-echo {
   position: fixed;
   top: 0;
   left: 0;
@@ -455,7 +485,7 @@ body.has-3d-world .bg-background {
   z-index: 80;
   border-radius: 9999px;
   will-change: transform;
-  transition: width 0.25s ease, height 0.25s ease, background-color 0.25s ease, border-color 0.25s ease;
+  transition: width 0.25s ease, height 0.25s ease, background-color 0.25s ease, border-color 0.25s ease, opacity 0.24s ease;
 }
 .companion-orb {
   width: 28px;
@@ -470,14 +500,41 @@ body.has-3d-world .bg-background {
   border: 1px solid rgba(255, 255, 255, 0.35);
   mix-blend-mode: difference;
 }
+.companion-shadow {
+  width: 36px;
+  height: 14px;
+  background: radial-gradient(ellipse at center, rgba(0, 0, 0, 0.28), transparent 70%);
+  filter: blur(4px);
+  opacity: 0.5;
+  z-index: 79;
+  mix-blend-mode: multiply;
+}
+.companion-echo {
+  width: 16px;
+  height: 16px;
+  background: rgba(255, 255, 255, 0.58);
+  opacity: 0;
+  z-index: 79;
+  mix-blend-mode: difference;
+}
 .companion-orb.companion-hover {
   width: 48px;
   height: 48px;
   background: rgba(168, 85, 247, 0.9);
   transform: translate3d(var(--x, 0), var(--y, 0), 0) scale(1.15);
 }
+.companion-orb.companion-card {
+  width: 17px;
+  height: 17px;
+  background: rgba(255, 255, 255, 0.86);
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  box-shadow: 0 0 24px rgba(168, 85, 247, 0.45);
+}
 .companion-orb.companion-press {
   background: rgba(34, 211, 238, 0.9);
+}
+.companion-hidden {
+  opacity: 0 !important;
 }
 
 /* Hide the OS cursor on the magic chrome — kept the default cursor everywhere
@@ -509,57 +566,158 @@ body.has-3d-world .bg-background {
    Mouse moves over the card → --tilt-x and --tilt-y vars are set, GPU
    applies perspective transform. Inner glow tracks cursor via --mouse-x/y.
    ============================================ */
+.depth-grid {
+  perspective: 1400px;
+  perspective-origin: 50% 30%;
+  transform-style: preserve-3d;
+}
+
+.depth-grid .tilt-3d.is-neighbor-reacting {
+  filter: brightness(var(--neighbor-brightness, 0.85)) saturate(var(--neighbor-saturation, 0.9));
+}
+
+.depth-scene {
+  perspective: 1800px;
+  perspective-origin: 50% 30%;
+  transform-style: preserve-3d;
+}
+
+.depth-layer-1,
+.depth-layer-2,
+.depth-layer-3,
+.depth-layer-4,
+.tilt-3d-pop {
+  transform-style: preserve-3d;
+  transition: transform 0.7s cubic-bezier(0.34, 1.56, 0.64, 1), filter 0.35s ease;
+  will-change: transform;
+}
+
+.depth-layer-1 { transform: translateZ(12px); }
+.depth-layer-2,
+.tilt-3d-pop { transform: translateZ(24px); }
+.depth-layer-3 { transform: translateZ(40px); }
+.depth-layer-4 { transform: translateZ(64px); }
+
 .tilt-3d {
+  --tilt-x: 0deg;
+  --tilt-y: 0deg;
+  --scale: 1;
+  --lift-z: 0px;
+  --neighbor-tilt-y: 0deg;
   position: relative;
   transform-style: preserve-3d;
   perspective: 1100px;
-  transition: transform 0.25s cubic-bezier(0.16, 1, 0.3, 1);
-  transform: perspective(1100px) rotateX(var(--tilt-x, 0deg)) rotateY(var(--tilt-y, 0deg)) scale(var(--scale, 1));
-  will-change: transform;
-}
-.tilt-3d::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  background: radial-gradient(circle 380px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(var(--glow-color, 168, 85, 247), 0.22), transparent 55%);
-  opacity: 0;
-  transition: opacity 0.3s ease;
-  pointer-events: none;
-  z-index: 1;
-}
-.tilt-3d:hover::before {
-  opacity: 1;
-}
-.tilt-3d::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  box-shadow: 0 0 0 transparent;
-  transition: box-shadow 0.35s ease;
-  pointer-events: none;
-}
-.tilt-3d:hover::after {
-  box-shadow:
-    0 0 0 1px rgba(var(--glow-color, 168, 85, 247), 0.25),
-    0 25px 60px -15px rgba(var(--glow-color, 168, 85, 247), 0.45),
-    0 50px 110px -30px rgba(0, 0, 0, 0.5);
-}
-/* All direct children sit above the ::before/::after pseudo-elements */
-.tilt-3d > * {
-  position: relative;
-  z-index: 2;
+  transition:
+    transform 0.7s cubic-bezier(0.34, 1.56, 0.64, 1),
+    box-shadow 0.35s ease,
+    filter 0.35s ease;
+  transform:
+    perspective(1100px)
+    translate3d(0, var(--rest-y, 0px), 0)
+    translateZ(var(--lift-z, 0px))
+    rotateX(var(--tilt-x, 0deg))
+    rotateY(calc(var(--tilt-y, 0deg) + var(--neighbor-tilt-y, 0deg)))
+    scale(var(--scale, 1));
+  box-shadow: 0 10px 30px -12px rgba(0, 0, 0, 0.45);
+  will-change: transform, filter;
+  animation: depth-rest 6s ease-in-out infinite;
 }
 
-/* When tilt is applied, lift child images slightly via translateZ for depth */
-.tilt-3d:hover img,
-.tilt-3d:hover .tilt-3d-pop {
-  transform: translateZ(28px);
+.tilt-3d.is-hovered {
+  animation-play-state: paused;
+  box-shadow:
+    0 0 0 1px rgba(var(--glow-color, 168, 85, 247), 0.22),
+    0 30px 60px -22px rgba(0, 0, 0, 0.62),
+    0 35px 80px -28px rgba(var(--glow-color, 168, 85, 247), 0.38);
+  transition-duration: 0.22s, 0.35s, 0.35s;
 }
-.tilt-3d img,
-.tilt-3d .tilt-3d-pop {
-  transition: transform 0.45s cubic-bezier(0.16, 1, 0.3, 1);
+
+.rim-light::before,
+.specular-highlight::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+}
+
+.rim-light::before {
+  padding: 1px;
+  background:
+    conic-gradient(
+      from var(--rim-angle, 0deg) at var(--mouse-x, 50%) var(--mouse-y, 50%),
+      transparent 0deg,
+      rgba(255, 255, 255, 0.72) 28deg,
+      rgba(var(--glow-color, 168, 85, 247), 0.4) 58deg,
+      transparent 118deg,
+      transparent 360deg
+    );
+  opacity: 0;
+  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  transition: opacity 0.28s ease;
+  z-index: 4;
+}
+
+.specular-highlight::after {
+  background: radial-gradient(circle 240px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255,255,255,0.22), transparent 60%);
+  mix-blend-mode: overlay;
+  opacity: 0;
+  transition: opacity 0.28s ease;
+  z-index: 5;
+}
+
+.tilt-3d.is-hovered::before,
+.tilt-3d.is-hovered::after {
+  opacity: 1;
+}
+
+.tilt-3d > * {
+  position: relative;
+  z-index: 3;
+  transform-style: preserve-3d;
+}
+
+.tilt-3d img {
+  transform: translateZ(18px);
+  transition: transform 0.7s cubic-bezier(0.34, 1.56, 0.64, 1), filter 0.35s ease;
+  will-change: transform;
+}
+
+.tilt-3d[data-tilt-depth="strong"] .depth-layer-1 { transform: translateZ(18px); }
+.tilt-3d[data-tilt-depth="strong"] .depth-layer-2,
+.tilt-3d[data-tilt-depth="strong"] .tilt-3d-pop { transform: translateZ(36px); }
+.tilt-3d[data-tilt-depth="strong"] .depth-layer-3 { transform: translateZ(50px); }
+.tilt-3d[data-tilt-depth="strong"] .depth-layer-4 { transform: translateZ(60px); }
+
+.tilt-3d[data-tilt-depth="subtle"] .depth-layer-1 { transform: translateZ(8px); }
+.tilt-3d[data-tilt-depth="subtle"] .depth-layer-2,
+.tilt-3d[data-tilt-depth="subtle"] .tilt-3d-pop { transform: translateZ(14px); }
+.tilt-3d[data-tilt-depth="subtle"] .depth-layer-3 { transform: translateZ(22px); }
+.tilt-3d[data-tilt-depth="subtle"] .depth-layer-4 { transform: translateZ(30px); }
+
+.magnetic {
+  transform: translate3d(var(--mag-x, 0px), var(--mag-y, 0px), 0);
+  transition: transform 0.25s cubic-bezier(.2,.9,.3,1.2);
+  will-change: transform;
+}
+
+.reveal-3d {
+  opacity: 0;
+  transform: translate3d(0, 80px, -120px) rotateX(-10deg);
+  filter: blur(14px);
+  transition:
+    opacity .9s cubic-bezier(.16,1,.3,1),
+    transform .9s cubic-bezier(.16,1,.3,1),
+    filter .9s cubic-bezier(.16,1,.3,1);
+  will-change: opacity, transform, filter;
+}
+
+.reveal-3d.is-in {
+  opacity: 1;
+  transform: none;
+  filter: none;
 }
 
 /* ============================================
@@ -905,5 +1063,60 @@ body.depth-mode .floating-item {
   .weather-mask-tornado,
   .weather-mask-hurricane {
     animation: none !important;
+  }
+
+  #main-content,
+  .depth-scene,
+  .depth-grid,
+  .tilt-3d,
+  .tilt-3d *,
+  .depth-layer-1,
+  .depth-layer-2,
+  .depth-layer-3,
+  .depth-layer-4,
+  .tilt-3d-pop,
+  .magnetic {
+    transform: none !important;
+    filter: none !important;
+    animation: none !important;
+  }
+
+  .reveal-3d {
+    opacity: 0;
+    transform: none !important;
+    filter: none !important;
+  }
+
+  .reveal-3d.is-in {
+    opacity: 1;
+  }
+
+  .tilt-3d::before,
+  .tilt-3d::after {
+    opacity: 0 !important;
+  }
+
+  .aurora-fallback-blob {
+    display: block;
+  }
+}
+
+@media (pointer: coarse) {
+  .tilt-3d,
+  .depth-grid .tilt-3d.is-neighbor-reacting,
+  .depth-layer-1,
+  .depth-layer-2,
+  .depth-layer-3,
+  .depth-layer-4,
+  .tilt-3d-pop,
+  .magnetic {
+    transform: none !important;
+    filter: none !important;
+    animation: none !important;
+  }
+
+  .tilt-3d::before,
+  .tilt-3d::after {
+    opacity: 0 !important;
   }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -229,12 +229,18 @@ body {
   font-feature-settings: "ss01", "cv11";
 }
 
-#main-content {
+.scroll-tilt-stage {
   transform: rotateX(var(--scroll-tilt, 0deg));
-  transform-origin: 50% 18vh;
+  transform-origin: 50% 30%;
   transform-style: preserve-3d;
   transition: transform 0.3s cubic-bezier(0.2, 0.9, 0.3, 1);
   will-change: transform;
+}
+
+section.no-scroll-tilt .scroll-tilt-stage {
+  transform: none;
+  transition: none;
+  will-change: auto;
 }
 
 /* Display headings get tighter tracking + optical balance */
@@ -1108,6 +1114,7 @@ body.depth-mode .floating-item {
   }
 
   #main-content,
+  .scroll-tilt-stage,
   .depth-scene,
   .depth-grid,
   .tilt-3d,
@@ -1145,6 +1152,7 @@ body.depth-mode .floating-item {
 
 @media (pointer: coarse) {
   .tilt-3d,
+  .scroll-tilt-stage,
   .depth-grid .tilt-3d.is-neighbor-reacting,
   .depth-layer-1,
   .depth-layer-2,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -588,6 +588,20 @@ body.has-3d-world .bg-background {
   transform-style: preserve-3d;
 }
 
+.chapter-pin {
+  --chapter-t: 0;
+  min-height: 200vh;
+}
+
+.chapter-content {
+  transform:
+    rotateY(calc((var(--chapter-t, 0) - 0.5) * 16deg))
+    translateZ(calc(var(--chapter-t, 0) * 40px));
+  transform-style: preserve-3d;
+  transition: transform 0.18s linear;
+  will-change: transform;
+}
+
 .depth-layer-1,
 .depth-layer-2,
 .depth-layer-3,
@@ -1145,6 +1159,19 @@ body.depth-mode .floating-item {
     opacity: 0 !important;
   }
 
+  .chapter-pin {
+    min-height: auto;
+  }
+
+  .chapter-stage {
+    position: static !important;
+    height: auto !important;
+  }
+
+  .chapter-content {
+    transform: none !important;
+  }
+
   .aurora-fallback-blob {
     display: block;
   }
@@ -1168,5 +1195,18 @@ body.depth-mode .floating-item {
   .tilt-3d::before,
   .tilt-3d::after {
     opacity: 0 !important;
+  }
+
+  .chapter-pin {
+    min-height: auto;
+  }
+
+  .chapter-stage {
+    position: static !important;
+    height: auto !important;
+  }
+
+  .chapter-content {
+    transform: none !important;
   }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -602,6 +602,13 @@ body.has-3d-world .bg-background {
   will-change: transform;
 }
 
+.hero-zoom-out {
+  transform: scale(calc(1.18 - var(--section-scroll-t, 0) * 0.18));
+  transform-origin: 50% 50%;
+  transition: transform 0.15s linear;
+  will-change: transform;
+}
+
 .depth-layer-1,
 .depth-layer-2,
 .depth-layer-3,
@@ -1172,6 +1179,10 @@ body.depth-mode .floating-item {
     transform: none !important;
   }
 
+  .hero-zoom-out {
+    transform: none !important;
+  }
+
   .aurora-fallback-blob {
     display: block;
   }
@@ -1207,6 +1218,10 @@ body.depth-mode .floating-item {
   }
 
   .chapter-content {
+    transform: none !important;
+  }
+
+  .hero-zoom-out {
     transform: none !important;
   }
 }

--- a/src/app/hidden-gems/page.tsx
+++ b/src/app/hidden-gems/page.tsx
@@ -185,7 +185,7 @@ export default function HiddenGemsPage() {
                 <TiltCard3D maxTilt={18} glowColor="251, 191, 36" tiltDepth={index === 0 ? "strong" : "medium"} className="h-full rounded-2xl">
               <div className="official-card group relative rounded-2xl border border-border/60 bg-surface card-hover-glow transition-all h-full flex flex-col overflow-hidden">
                 <div className="overflow-hidden relative depth-layer-1">
-                  <ItemImage slug={item.slug} alt={item.name} aspectRatio="3/2" width={400} height={267} priority={index < 4} className="group-hover:scale-[1.03] transition-transform duration-500" />
+                  <ItemImage slug={item.slug} alt={item.name} aspectRatio="3/2" width={400} height={267} priority={index < 4} className={`${index === 0 ? "hero-zoom-out " : ""}group-hover:scale-[1.03] transition-transform duration-500`} />
                   {item.badge === "editors-pick" && (
                     <span className="absolute top-2 left-2 z-10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider bg-amber-500/90 text-black rounded depth-layer-3">
                       Editor&apos;s Pick

--- a/src/app/hidden-gems/page.tsx
+++ b/src/app/hidden-gems/page.tsx
@@ -72,7 +72,7 @@ export default function HiddenGemsPage() {
         colorC="bg-yellow-500/6"
         className="depth-scene py-24 sm:py-32"
       >
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 text-center">
+        <div className="scroll-tilt-stage mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 text-center">
           <p className="text-xs font-semibold uppercase tracking-[0.2em] text-amber-400 mb-4">
             Hidden Gems
           </p>
@@ -166,22 +166,23 @@ export default function HiddenGemsPage() {
 
       {/* ── Results Grid ──────────────────────────────────── */}
       <section className="depth-scene mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 pb-20">
-        <p className="text-sm text-muted-foreground mb-6">
-          Showing{" "}
-          <span className="font-semibold text-foreground">
-            {filtered.length === 0 ? 0 : (page - 1) * PER_PAGE + 1}–{Math.min(page * PER_PAGE, filtered.length)}
-          </span>{" "}
-          of{" "}
-          <span className="font-semibold text-foreground">{filtered.length}</span>{" "}
-          items
-        </p>
+        <div className="scroll-tilt-stage">
+          <p className="text-sm text-muted-foreground mb-6">
+            Showing{" "}
+            <span className="font-semibold text-foreground">
+              {filtered.length === 0 ? 0 : (page - 1) * PER_PAGE + 1}–{Math.min(page * PER_PAGE, filtered.length)}
+            </span>{" "}
+            of{" "}
+            <span className="font-semibold text-foreground">{filtered.length}</span>{" "}
+            items
+          </p>
 
-        {/* AD_ZONE: sidebar */}
+          {/* AD_ZONE: sidebar */}
 
-        <div className="depth-grid grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
-          {paginatedItems.map((item, index) => (
-            <ScrollReveal key={item.slug} delay={Math.min(index * 50, 800)} placeholder={<SkeletonCard />} className={index === 0 ? "sm:col-span-2 lg:col-span-2 xl:col-span-2" : ""}>
-              <TiltCard3D maxTilt={18} glowColor="251, 191, 36" tiltDepth={index === 0 ? "strong" : "medium"} className="h-full rounded-2xl">
+          <div className="depth-grid grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
+            {paginatedItems.map((item, index) => (
+              <ScrollReveal key={item.slug} delay={Math.min(index * 50, 800)} placeholder={<SkeletonCard />} className={index === 0 ? "sm:col-span-2 lg:col-span-2 xl:col-span-2" : ""}>
+                <TiltCard3D maxTilt={18} glowColor="251, 191, 36" tiltDepth={index === 0 ? "strong" : "medium"} className="h-full rounded-2xl">
               <div className="official-card group relative rounded-2xl border border-border/60 bg-surface card-hover-glow transition-all h-full flex flex-col overflow-hidden">
                 <div className="overflow-hidden relative depth-layer-1">
                   <ItemImage slug={item.slug} alt={item.name} aspectRatio="3/2" width={400} height={267} priority={index < 4} className="group-hover:scale-[1.03] transition-transform duration-500" />
@@ -230,36 +231,37 @@ export default function HiddenGemsPage() {
                 )}
                 </div>
               </div>
-              </TiltCard3D>
-            </ScrollReveal>
-          ))}
+                </TiltCard3D>
+              </ScrollReveal>
+            ))}
+          </div>
+
+          {filtered.length === 0 && (
+            <div className="text-center py-16">
+              <p className="text-muted-foreground">No hidden gems match your search.</p>
+            </div>
+          )}
+
+          {totalPages > 1 && (
+            <div className="flex items-center justify-center gap-2 mt-8">
+              <button
+                onClick={() => { setPage(p => Math.max(1, p - 1)); window.scrollTo({ top: 0, behavior: "smooth" }); }}
+                disabled={page === 1}
+                className="px-3 py-1.5 rounded-lg border border-border text-sm disabled:opacity-30 hover:bg-card transition-colors"
+              >
+                ← Previous
+              </button>
+              <span className="text-sm text-muted-foreground px-3">Page {page} of {totalPages}</span>
+              <button
+                onClick={() => { setPage(p => Math.min(totalPages, p + 1)); window.scrollTo({ top: 0, behavior: "smooth" }); }}
+                disabled={page === totalPages}
+                className="px-3 py-1.5 rounded-lg border border-border text-sm disabled:opacity-30 hover:bg-card transition-colors"
+              >
+                Next →
+              </button>
+            </div>
+          )}
         </div>
-
-        {filtered.length === 0 && (
-          <div className="text-center py-16">
-            <p className="text-muted-foreground">No hidden gems match your search.</p>
-          </div>
-        )}
-
-        {totalPages > 1 && (
-          <div className="flex items-center justify-center gap-2 mt-8">
-            <button
-              onClick={() => { setPage(p => Math.max(1, p - 1)); window.scrollTo({ top: 0, behavior: "smooth" }); }}
-              disabled={page === 1}
-              className="px-3 py-1.5 rounded-lg border border-border text-sm disabled:opacity-30 hover:bg-card transition-colors"
-            >
-              ← Previous
-            </button>
-            <span className="text-sm text-muted-foreground px-3">Page {page} of {totalPages}</span>
-            <button
-              onClick={() => { setPage(p => Math.min(totalPages, p + 1)); window.scrollTo({ top: 0, behavior: "smooth" }); }}
-              disabled={page === totalPages}
-              className="px-3 py-1.5 rounded-lg border border-border text-sm disabled:opacity-30 hover:bg-card transition-colors"
-            >
-              Next →
-            </button>
-          </div>
-        )}
       </section>
 
       {/* ── Explore Another Category ─────────────────────── */}

--- a/src/app/hidden-gems/page.tsx
+++ b/src/app/hidden-gems/page.tsx
@@ -14,7 +14,7 @@ import { LogoImage } from "@/components/ui/LogoImage";
 import { QuickViewModal } from "@/components/ui/QuickViewModal";
 import { AuroraBackground } from "@/components/ui/AuroraBackground";
 import { BlurText } from "@/components/ui/BlurText";
-import { TiltCard } from "@/components/ui/TiltCard";
+import { TiltCard3D } from "@/components/ui/TiltCard3D";
 import { EditorialTrustBar } from "@/components/ui/EditorialTrustBar";
 import { SourceTrailLink } from "@/components/ui/SourceTrailLink";
 import { filterLiveOutboundUrl } from "@/lib/dead-links";
@@ -70,7 +70,7 @@ export default function HiddenGemsPage() {
         colorA="bg-amber-500/15"
         colorB="bg-orange-500/10"
         colorC="bg-yellow-500/6"
-        className="py-24 sm:py-32"
+        className="depth-scene py-24 sm:py-32"
       >
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 text-center">
           <p className="text-xs font-semibold uppercase tracking-[0.2em] text-amber-400 mb-4">
@@ -165,7 +165,7 @@ export default function HiddenGemsPage() {
       </section>
 
       {/* ── Results Grid ──────────────────────────────────── */}
-      <section className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 pb-20">
+      <section className="depth-scene mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 pb-20">
         <p className="text-sm text-muted-foreground mb-6">
           Showing{" "}
           <span className="font-semibold text-foreground">
@@ -178,31 +178,31 @@ export default function HiddenGemsPage() {
 
         {/* AD_ZONE: sidebar */}
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
+        <div className="depth-grid grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
           {paginatedItems.map((item, index) => (
             <ScrollReveal key={item.slug} delay={Math.min(index * 50, 800)} placeholder={<SkeletonCard />} className={index === 0 ? "sm:col-span-2 lg:col-span-2 xl:col-span-2" : ""}>
-              <TiltCard maxTilt={6} glowColor="0 8px 40px rgba(251,191,36,0.12), 0 0 0 1px rgba(251,191,36,0.08)" className="h-full">
+              <TiltCard3D maxTilt={18} glowColor="251, 191, 36" tiltDepth={index === 0 ? "strong" : "medium"} className="h-full rounded-2xl">
               <div className="official-card group relative rounded-2xl border border-border/60 bg-surface card-hover-glow transition-all h-full flex flex-col overflow-hidden">
-                <div className="overflow-hidden relative">
+                <div className="overflow-hidden relative depth-layer-1">
                   <ItemImage slug={item.slug} alt={item.name} aspectRatio="3/2" width={400} height={267} priority={index < 4} className="group-hover:scale-[1.03] transition-transform duration-500" />
                   {item.badge === "editors-pick" && (
-                    <span className="absolute top-2 left-2 z-10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider bg-amber-500/90 text-black rounded">
+                    <span className="absolute top-2 left-2 z-10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider bg-amber-500/90 text-black rounded depth-layer-3">
                       Editor&apos;s Pick
                     </span>
                   )}
                   <button
                     onClick={() => setQuickViewItem(item as AnyItem)}
-                    className="absolute inset-0 z-20 flex items-center justify-center bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity"
+                    className="magnetic absolute inset-0 z-20 flex items-center justify-center bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity"
                   >
                     <span className="px-3 py-1.5 bg-white text-black text-xs font-semibold rounded-full shadow">Quick View</span>
                   </button>
                 </div>
                 <div className="p-6 flex flex-col flex-1">
-                <div className="flex items-start justify-between gap-2 mb-3">
+                <div className="depth-layer-3 flex items-start justify-between gap-2 mb-3">
                   <CategoryBadge label={item.category} color="amber" />
                   <BookmarkButton slug={item.slug} />
                 </div>
-                <Link href={`/item/${item.slug}`} aria-label={`Read ${item.name}`} className="block mb-2">
+                <Link href={`/item/${item.slug}`} aria-label={`Read ${item.name}`} className="depth-layer-2 block mb-2">
                   <h2 className="text-base font-semibold text-foreground group-hover:text-amber-300 transition-colors line-clamp-2 flex items-center gap-1.5">
                     {hostForLiveUrl(item.websiteLink) && (
                       <LogoImage domain={hostForLiveUrl(item.websiteLink) || ""} />
@@ -214,7 +214,7 @@ export default function HiddenGemsPage() {
                   {getItemExcerpt(item)}
                 </p>
                 {filterLiveOutboundUrl(item.websiteLink) && (
-                <div className="mt-auto flex flex-col gap-3">
+                <div className="depth-layer-4 mt-auto flex flex-col gap-3">
                   <SourceTrailLink href={filterLiveOutboundUrl(item.websiteLink)!} label="Official site" compact />
                   <a
                     href={filterLiveOutboundUrl(item.websiteLink)!}
@@ -222,7 +222,7 @@ export default function HiddenGemsPage() {
                     rel="noopener noreferrer"
                     data-outbound="true"
                     onClick={(e) => e.stopPropagation()}
-                    className="inline-flex items-center text-xs font-semibold text-amber-400 hover:text-amber-300 transition-colors"
+                    className="magnetic inline-flex items-center text-xs font-semibold text-amber-400 hover:text-amber-300 transition-colors"
                   >
                     Visit Site →
                   </a>
@@ -230,7 +230,7 @@ export default function HiddenGemsPage() {
                 )}
                 </div>
               </div>
-              </TiltCard>
+              </TiltCard3D>
             </ScrollReveal>
           ))}
         </div>

--- a/src/app/hidden-gems/page.tsx
+++ b/src/app/hidden-gems/page.tsx
@@ -222,7 +222,7 @@ export default function HiddenGemsPage() {
                     rel="noopener noreferrer"
                     data-outbound="true"
                     onClick={(e) => e.stopPropagation()}
-                    className="magnetic inline-flex items-center text-xs font-semibold text-amber-400 hover:text-amber-300 transition-colors"
+                    className="inline-flex items-center text-xs font-semibold text-amber-400 hover:text-amber-300 transition-colors"
                   >
                     Visit Site →
                   </a>

--- a/src/app/item/[slug]/page.tsx
+++ b/src/app/item/[slug]/page.tsx
@@ -346,7 +346,7 @@ export default async function ItemPage({ params }: Props) {
       </div>
 
       <section className="depth-scene py-12 sm:py-16">
-        <div className="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
+        <div className="scroll-tilt-stage mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
           {/* ── Visible breadcrumbs ─────────────────────────── */}
           <nav aria-label="Breadcrumb" className="mb-8">
             <ol className="flex items-center gap-1.5 text-sm text-muted-foreground flex-wrap">

--- a/src/app/item/[slug]/page.tsx
+++ b/src/app/item/[slug]/page.tsx
@@ -326,7 +326,7 @@ export default async function ItemPage({ params }: Props) {
       {/* ── Hero image — sits on the global 3D world ──── */}
       <div
         data-world-scene={`item-${item.type}`}
-        className="w-full overflow-hidden border-b border-white/[0.06] relative"
+        className="depth-scene w-full overflow-hidden border-b border-white/[0.06] relative"
       >
         <div className="absolute inset-0 world-scrim pointer-events-none" aria-hidden="true" />
         <div className="relative z-10">
@@ -334,7 +334,7 @@ export default async function ItemPage({ params }: Props) {
             <ScreenshotImage src={(item as HiddenGem).screenshotUrl!} alt={title} />
           ) : (
             <>
-              <ItemImage slug={slug} alt={title} width={1200} height={686} aspectRatio="16/7" size="lg" priority />
+              <ItemImage slug={slug} alt={title} width={1200} height={686} aspectRatio="16/7" size="lg" priority className="hero-zoom-out" />
               {isPexelsImage(slug) && (
                 <p className="absolute bottom-2 right-3 text-[10px] text-white/60">
                   Photo via Pexels

--- a/src/app/item/[slug]/page.tsx
+++ b/src/app/item/[slug]/page.tsx
@@ -53,6 +53,7 @@ import type { Metadata } from "next";
 import { alcoveFromCategory } from "@/lib/alcoves";
 import { ItemWorldSeeder } from "@/components/3d/ItemWorldSeeder";
 import { BYLINE } from "@/lib/masthead";
+import { TiltCard3D } from "@/components/ui/TiltCard3D";
 // AlcoveFromCategory still used in jsonld + scene labelling
 void alcoveFromCategory;
 
@@ -344,7 +345,7 @@ export default async function ItemPage({ params }: Props) {
         </div>
       </div>
 
-      <section className="py-12 sm:py-16">
+      <section className="depth-scene py-12 sm:py-16">
         <div className="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
           {/* ── Visible breadcrumbs ─────────────────────────── */}
           <nav aria-label="Breadcrumb" className="mb-8">
@@ -565,7 +566,7 @@ export default async function ItemPage({ params }: Props) {
                     data-item-category={category}
                     data-item-type={item.type}
                     id="main-cta-button"
-                    className={`inline-flex items-center gap-2.5 px-8 py-4 rounded-xl font-bold text-base hover:-translate-y-0.5 transition-all ${
+                    className={`magnetic inline-flex items-center gap-2.5 px-8 py-4 rounded-xl font-bold text-base hover:-translate-y-0.5 transition-all ${
                       item.type === "product" && (isAffiliate && item.affiliate?.provider === "amazon" || outboundUrl?.includes("amazon.com"))
                         ? ctaStyles["product-amazon"] + " text-black"
                         : "text-white " + (ctaStyles[item.type] || ctaStyles.default)
@@ -674,27 +675,36 @@ export default async function ItemPage({ params }: Props) {
                     From {crossItems.map((i) => getCategoryLabel(i.type)).filter((v, i, a) => a.indexOf(v) === i).join(" · ")}
                   </span>
                 </div>
-                <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                <div className="depth-grid grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
                   {crossItems.map((related) => {
                     const relTitle = getItemTitle(related);
                     const relColor = getCategoryColor(related.type);
                     const relLabel = getCategoryLabel(related.type);
                     return (
-                      <Link
+                      <TiltCard3D
                         key={related.slug}
+                        className="rounded-xl h-full"
+                        tiltDepth="medium"
+                        maxTilt={14}
+                        glowColor="168, 85, 247"
+                      >
+                      <Link
                         href={`/item/${related.slug}`}
                         aria-label={`Read ${relTitle}`}
                         className="group relative rounded-xl border border-border bg-card overflow-hidden card-hover-glow transition-all flex flex-col"
                       >
-                        <ItemImage slug={related.slug} alt={relTitle} aspectRatio="3/2" width={400} height={267} size="sm" className="group-hover:scale-[1.03] transition-transform duration-500" />
+                        <div className="depth-layer-1">
+                          <ItemImage slug={related.slug} alt={relTitle} aspectRatio="3/2" width={400} height={267} size="sm" className="group-hover:scale-[1.03] transition-transform duration-500" />
+                        </div>
                         <div className="p-4 flex flex-col flex-1">
-                          <CategoryBadge color={relColor} label={relLabel} className="mb-2" />
-                          <h3 className="text-sm font-semibold text-foreground group-hover:text-accent-hover transition-colors line-clamp-2 mb-2 flex-1">
+                          <CategoryBadge color={relColor} label={relLabel} className="depth-layer-3 mb-2" />
+                          <h3 className="depth-layer-2 text-sm font-semibold text-foreground group-hover:text-accent-hover transition-colors line-clamp-2 mb-2 flex-1">
                             {relTitle}
                           </h3>
                           <p className="text-xs text-muted-foreground line-clamp-2">{getItemExcerpt(related)}</p>
                         </div>
                       </Link>
+                      </TiltCard3D>
                     );
                   })}
                 </div>
@@ -716,55 +726,72 @@ export default async function ItemPage({ params }: Props) {
                     View all <span>&rarr;</span>
                   </Link>
                 </div>
-                <div className="hidden sm:grid sm:grid-cols-3 gap-4">
+                <div className="depth-grid hidden sm:grid sm:grid-cols-3 gap-4">
                   {moreFromCategory.map((related) => {
                     const relTitle = getItemTitle(related);
                     const relColor = getCategoryColor(related.type);
                     const relLabel = getCategoryLabel(related.type);
                     const hasAmazon = !!(related as { directAmazonUrl?: string }).directAmazonUrl || !!(related as { affiliate?: { enabled?: boolean } }).affiliate?.enabled;
                     return (
-                      <Link
+                      <TiltCard3D
                         key={related.slug}
+                        className="rounded-xl h-full"
+                        tiltDepth="medium"
+                        maxTilt={14}
+                        glowColor="168, 85, 247"
+                      >
+                      <Link
                         href={`/item/${related.slug}`}
                         aria-label={`Read ${relTitle}`}
                         className="group relative rounded-xl border border-border bg-card overflow-hidden card-hover-glow transition-all flex flex-col"
                       >
                         {hasAmazon && (
-                          <span className="absolute top-2 left-2 z-10 text-[10px] font-medium bg-amber-500/20 text-amber-300 border border-amber-400/30 px-1.5 py-0.5 rounded-full">
+                          <span className="depth-layer-3 absolute top-2 left-2 z-10 text-[10px] font-medium bg-amber-500/20 text-amber-300 border border-amber-400/30 px-1.5 py-0.5 rounded-full">
                             🛒 On Amazon
                           </span>
                         )}
-                        <ItemImage slug={related.slug} alt={relTitle} aspectRatio="3/2" width={400} height={267} size="sm" className="group-hover:scale-[1.03] transition-transform duration-500" />
+                        <div className="depth-layer-1">
+                          <ItemImage slug={related.slug} alt={relTitle} aspectRatio="3/2" width={400} height={267} size="sm" className="group-hover:scale-[1.03] transition-transform duration-500" />
+                        </div>
                         <div className="p-4 flex flex-col flex-1">
-                          <CategoryBadge color={relColor} label={relLabel} className="mb-2" />
-                          <h3 className="text-sm font-semibold text-foreground group-hover:text-accent transition-colors line-clamp-2 mb-2 flex-1">
+                          <CategoryBadge color={relColor} label={relLabel} className="depth-layer-3 mb-2" />
+                          <h3 className="depth-layer-2 text-sm font-semibold text-foreground group-hover:text-accent transition-colors line-clamp-2 mb-2 flex-1">
                             {relTitle}
                           </h3>
-                          <span className="text-xs text-accent font-medium">Read →</span>
+                          <span className="depth-layer-4 text-xs text-accent font-medium">Read →</span>
                         </div>
                       </Link>
+                      </TiltCard3D>
                     );
                   })}
                 </div>
-                <div className="sm:hidden flex gap-3 overflow-x-auto pb-2" style={{ scrollbarWidth: "none" } as React.CSSProperties}>
+                <div className="depth-grid sm:hidden flex gap-3 overflow-x-auto pb-2" style={{ scrollbarWidth: "none" } as React.CSSProperties}>
                   {moreFromCategory.map((related) => {
                     const relTitle = getItemTitle(related);
                     const relColor = getCategoryColor(related.type);
                     const relLabel = getCategoryLabel(related.type);
                     const hasAmazon = !!(related as { directAmazonUrl?: string }).directAmazonUrl || !!(related as { affiliate?: { enabled?: boolean } }).affiliate?.enabled;
                     return (
-                      <Link
+                      <TiltCard3D
                         key={related.slug}
+                        className="shrink-0 w-[200px] rounded-xl"
+                        tiltDepth="subtle"
+                        maxTilt={8}
+                        glowColor="168, 85, 247"
+                      >
+                      <Link
                         href={`/item/${related.slug}`}
                         aria-label={`Read ${relTitle}`}
-                        className="group relative shrink-0 w-[200px] rounded-xl border border-border bg-card overflow-hidden card-hover-glow flex flex-col"
+                        className="group relative rounded-xl border border-border bg-card overflow-hidden card-hover-glow flex flex-col"
                       >
                         {hasAmazon && (
                           <span className="absolute top-2 left-2 z-10 text-[10px] font-medium bg-amber-500/20 text-amber-300 border border-amber-400/30 px-1.5 py-0.5 rounded-full">
                             🛒 On Amazon
                           </span>
                         )}
-                        <ItemImage slug={related.slug} alt={relTitle} aspectRatio="3/2" width={200} height={133} size="sm" className="group-hover:scale-[1.03] transition-transform duration-500" />
+                        <div className="depth-layer-1">
+                          <ItemImage slug={related.slug} alt={relTitle} aspectRatio="3/2" width={200} height={133} size="sm" className="group-hover:scale-[1.03] transition-transform duration-500" />
+                        </div>
                         <div className="p-3 flex flex-col flex-1">
                           <CategoryBadge color={relColor} label={relLabel} className="mb-2" />
                           <h3 className="text-xs font-semibold text-foreground group-hover:text-accent transition-colors line-clamp-2 mb-2 flex-1">
@@ -773,6 +800,7 @@ export default async function ItemPage({ params }: Props) {
                           <span className="text-xs text-accent font-medium">Read →</span>
                         </div>
                       </Link>
+                      </TiltCard3D>
                     );
                   })}
                 </div>

--- a/src/app/item/[slug]/page.tsx
+++ b/src/app/item/[slug]/page.tsx
@@ -566,7 +566,7 @@ export default async function ItemPage({ params }: Props) {
                     data-item-category={category}
                     data-item-type={item.type}
                     id="main-cta-button"
-                    className={`magnetic inline-flex items-center gap-2.5 px-8 py-4 rounded-xl font-bold text-base hover:-translate-y-0.5 transition-all ${
+                    className={`inline-flex items-center gap-2.5 px-8 py-4 rounded-xl font-bold text-base hover:-translate-y-0.5 transition-all ${
                       item.type === "product" && (isAffiliate && item.affiliate?.provider === "amazon" || outboundUrl?.includes("amazon.com"))
                         ? ctaStyles["product-amazon"] + " text-black"
                         : "text-white " + (ctaStyles[item.type] || ctaStyles.default)

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -386,7 +386,7 @@ function LeadCard({ item }: { item: AnyItem }) {
               rel="noopener noreferrer"
               data-outbound="true"
               data-cursor="hover"
-              className="magnetic inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-white/10 backdrop-blur-md text-white text-sm font-medium border border-white/20 hover:bg-white/20 transition-colors"
+              className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-white/10 backdrop-blur-md text-white text-sm font-medium border border-white/20 hover:bg-white/20 transition-colors"
             >
               Visit {host} ↗
             </a>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,6 +18,7 @@ import { TiltCard3D } from "@/components/ui/TiltCard3D";
 import { HomeStreakStatus, SearchSurfacedButton } from "@/components/home/HomeHeroActions";
 import { LiveNowTicker } from "@/components/home/LiveNowTicker";
 import { HeroParallax } from "@/components/home/HeroParallax";
+import { ChapterProgress } from "@/components/home/ChapterProgress";
 import { BYLINE } from "@/lib/masthead";
 
 function formatEditionDate(): string {
@@ -470,8 +471,9 @@ function AlcoveSection({ alcove, items, index }: { alcove: Alcove; items: AnyIte
   return (
     <section
       data-world-scene={`alcove-${alcove.kind}`}
-      className="depth-scene no-scroll-tilt relative min-h-[80vh] flex items-center overflow-hidden border-t border-white/[0.04]"
+      className="depth-scene no-scroll-tilt chapter-pin relative min-h-[200vh] overflow-hidden border-t border-white/[0.04]"
     >
+      <ChapterProgress />
       {/* World scrim adapts to global world rather than having its own canvas */}
       <div className="absolute inset-0 world-scrim pointer-events-none" aria-hidden="true" />
       <div
@@ -481,33 +483,35 @@ function AlcoveSection({ alcove, items, index }: { alcove: Alcove; items: AnyIte
         }}
         aria-hidden="true"
       />
-      <div className="scroll-tilt-stage relative z-10 max-w-7xl mx-auto px-4 sm:px-6 py-20 sm:py-28 w-full">
-        <div className={`flex flex-col ${flip ? "lg:flex-row-reverse" : "lg:flex-row"} gap-10 lg:gap-16 items-start`}>
-          <div className="lg:w-1/3 lg:sticky lg:top-28">
-            <p className="text-xs uppercase tracking-[0.25em] text-white/70 font-semibold mb-4">
-              Alcove · {String(index + 1).padStart(2, "0")} of 06
-            </p>
-            <h2 className="text-4xl sm:text-6xl font-bold text-white leading-[0.95] tracking-tight">
-              {alcove.label}
-            </h2>
-            <p className="mt-5 text-white/85 text-lg leading-relaxed max-w-md">
-              {alcove.tagline}
-            </p>
-            <Link
-              href={`/tools?category=${encodeURIComponent(alcove.label)}`}
-              data-cursor="hover"
-              className="mt-7 inline-flex items-center gap-2 px-5 py-2.5 rounded-full bg-white/10 backdrop-blur-md border border-white/20 text-white text-sm font-medium hover:bg-white/20 transition-colors"
-            >
-              See all {alcove.label} tools →
-            </Link>
-          </div>
+      <div className="chapter-stage sticky top-0 h-screen flex items-center">
+        <div className="chapter-content relative z-10 max-w-7xl mx-auto px-4 sm:px-6 py-16 sm:py-20 w-full">
+          <div className={`flex flex-col ${flip ? "lg:flex-row-reverse" : "lg:flex-row"} gap-10 lg:gap-16 items-start`}>
+            <div className="lg:w-1/3">
+              <p className="text-xs uppercase tracking-[0.25em] text-white/70 font-semibold mb-4">
+                Alcove · {String(index + 1).padStart(2, "0")} of 06
+              </p>
+              <h2 className="text-4xl sm:text-6xl font-bold text-white leading-[0.95] tracking-tight">
+                {alcove.label}
+              </h2>
+              <p className="mt-5 text-white/85 text-lg leading-relaxed max-w-md">
+                {alcove.tagline}
+              </p>
+              <Link
+                href={`/tools?category=${encodeURIComponent(alcove.label)}`}
+                data-cursor="hover"
+                className="mt-7 inline-flex items-center gap-2 px-5 py-2.5 rounded-full bg-white/10 backdrop-blur-md border border-white/20 text-white text-sm font-medium hover:bg-white/20 transition-colors"
+              >
+                See all {alcove.label} tools →
+              </Link>
+            </div>
 
-          <div className="depth-grid lg:w-2/3 grid grid-cols-1 sm:grid-cols-2 gap-4">
-            {items.map((item, i) => (
-              <ScrollReveal key={item.slug} delay={i * 90}>
-                <AlcoveItemCard item={item} />
-              </ScrollReveal>
-            ))}
+            <div className="depth-grid lg:w-2/3 grid grid-cols-1 sm:grid-cols-2 gap-4">
+              {items.map((item, i) => (
+                <ScrollReveal key={item.slug} delay={i * 90}>
+                  <AlcoveItemCard item={item} />
+                </ScrollReveal>
+              ))}
+            </div>
           </div>
         </div>
       </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -352,7 +352,7 @@ function LeadCard({ item }: { item: AnyItem }) {
           width={1200}
           height={750}
           priority
-          className="transition-transform duration-700 ease-out"
+          className="hero-zoom-out transition-transform duration-700 ease-out"
         />
         <div className="absolute inset-0 bg-gradient-to-t from-black/85 via-black/30 to-transparent" />
         <div className="absolute inset-0 mix-blend-overlay opacity-70" style={{

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -351,7 +351,6 @@ function LeadCard({ item }: { item: AnyItem }) {
           aspectRatio="16/10"
           width={1200}
           height={750}
-          priority
           className="hero-zoom-out transition-transform duration-700 ease-out"
         />
         <div className="absolute inset-0 bg-gradient-to-t from-black/85 via-black/30 to-transparent" />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -83,65 +83,67 @@ export default function HomePage() {
         <div className="absolute inset-0 world-scrim pointer-events-none" aria-hidden="true" />
         <HeroParallax />
 
-        <div className="relative z-10 max-w-5xl mx-auto px-4 sm:px-6 py-24 sm:py-32 text-center parallax-slow">
-          <div className="flex flex-wrap items-center justify-center gap-2 mb-6">
-            <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-white/10 border border-white/20 text-[10px] font-bold uppercase tracking-[0.18em] text-white backdrop-blur-md">
-              <span className="relative flex h-1.5 w-1.5">
-                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-white opacity-60" />
-                <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-white" />
+        <div className="scroll-tilt-stage relative z-10 w-full">
+          <div className="max-w-5xl mx-auto px-4 sm:px-6 py-24 sm:py-32 text-center parallax-slow">
+            <div className="flex flex-wrap items-center justify-center gap-2 mb-6">
+              <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-white/10 border border-white/20 text-[10px] font-bold uppercase tracking-[0.18em] text-white backdrop-blur-md">
+                <span className="relative flex h-1.5 w-1.5">
+                  <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-white opacity-60" />
+                  <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-white" />
+                </span>
+                Today&rsquo;s Edition
               </span>
-              Today&rsquo;s Edition
-            </span>
-            <span className="text-xs text-white/85">{editionDate}</span>
-            <HomeStreakStatus />
-          </div>
+              <span className="text-xs text-white/85">{editionDate}</span>
+              <HomeStreakStatus />
+            </div>
 
-          <h1 className="mx-auto max-w-4xl text-center text-5xl sm:text-7xl lg:text-8xl font-extrabold tracking-tight leading-[0.95] mb-6 text-white drop-shadow-[0_4px_30px_rgba(0,0,0,0.6)]">
-            Software worth
-            <span className="block bg-gradient-to-r from-violet-300 via-cyan-200 to-amber-200 bg-clip-text text-transparent">
-              your attention.
-            </span>
-          </h1>
-          <p className="text-base sm:text-xl text-white/90 max-w-2xl mx-auto leading-relaxed">
-            Surfaced is a hand-edited daily on the most useful tools, hidden web apps, and quiet
-            corners of the internet. One editor. No SEO slop. Real opinions on what to use.
-          </p>
-
-          <div className="mt-9 flex flex-col sm:flex-row items-center justify-center gap-3">
-            <Link
-              href="#today"
-              data-cursor="hover"
-              className="w-full sm:w-auto inline-flex items-center justify-center gap-2 px-7 py-3.5 rounded-xl bg-white text-black text-sm font-semibold hover:bg-white/90 transition-all shadow-[0_10px_40px_rgba(0,0,0,0.5)] active:scale-[0.98]"
-            >
-              Read today&rsquo;s edition
-              <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-                <path d="M8 3v10M4 9l4 4 4-4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-              </svg>
-            </Link>
-            <SearchSurfacedButton />
-          </div>
-
-          <div className="mt-10 flex flex-col items-center gap-5">
-            <p className="text-[11px] uppercase tracking-[0.25em] text-white/65">
-              {hiddenGems.length + dailyTools.length} curated · {alcoves.length} alcoves · Updated daily
+            <h1 className="mx-auto max-w-4xl text-center text-5xl sm:text-7xl lg:text-8xl font-extrabold tracking-tight leading-[0.95] mb-6 text-white drop-shadow-[0_4px_30px_rgba(0,0,0,0.6)]">
+              Software worth
+              <span className="block bg-gradient-to-r from-violet-300 via-cyan-200 to-amber-200 bg-clip-text text-transparent">
+                your attention.
+              </span>
+            </h1>
+            <p className="text-base sm:text-xl text-white/90 max-w-2xl mx-auto leading-relaxed">
+              Surfaced is a hand-edited daily on the most useful tools, hidden web apps, and quiet
+              corners of the internet. One editor. No SEO slop. Real opinions on what to use.
             </p>
-            <LiveNowTicker
-              items={allKept.slice(0, 30).map((i) => ({
-                slug: i.slug,
-                title: getItemTitle(i),
-                category: getItemCategory(i),
-                action: "open",
-              }))}
-            />
-            <Link
-              href="/roulette"
-              data-cursor="hover"
-              className="inline-flex items-center gap-2 text-[11px] uppercase tracking-[0.22em] text-white/75 hover:text-white transition-colors group"
-            >
-              <span className="block w-6 h-px bg-white/40 group-hover:bg-white transition-colors" />
-              Try the Tool Roulette
-              <span className="block w-6 h-px bg-white/40 group-hover:bg-white transition-colors" />
-            </Link>
+
+            <div className="mt-9 flex flex-col sm:flex-row items-center justify-center gap-3">
+              <Link
+                href="#today"
+                data-cursor="hover"
+                className="w-full sm:w-auto inline-flex items-center justify-center gap-2 px-7 py-3.5 rounded-xl bg-white text-black text-sm font-semibold hover:bg-white/90 transition-all shadow-[0_10px_40px_rgba(0,0,0,0.5)] active:scale-[0.98]"
+              >
+                Read today&rsquo;s edition
+                <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                  <path d="M8 3v10M4 9l4 4 4-4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+              </Link>
+              <SearchSurfacedButton />
+            </div>
+
+            <div className="mt-10 flex flex-col items-center gap-5">
+              <p className="text-[11px] uppercase tracking-[0.25em] text-white/65">
+                {hiddenGems.length + dailyTools.length} curated · {alcoves.length} alcoves · Updated daily
+              </p>
+              <LiveNowTicker
+                items={allKept.slice(0, 30).map((i) => ({
+                  slug: i.slug,
+                  title: getItemTitle(i),
+                  category: getItemCategory(i),
+                  action: "open",
+                }))}
+              />
+              <Link
+                href="/roulette"
+                data-cursor="hover"
+                className="inline-flex items-center gap-2 text-[11px] uppercase tracking-[0.22em] text-white/75 hover:text-white transition-colors group"
+              >
+                <span className="block w-6 h-px bg-white/40 group-hover:bg-white transition-colors" />
+                Try the Tool Roulette
+                <span className="block w-6 h-px bg-white/40 group-hover:bg-white transition-colors" />
+              </Link>
+            </div>
           </div>
         </div>
 
@@ -163,7 +165,7 @@ export default function HomePage() {
           className="depth-scene relative py-20 sm:py-28 px-4 sm:px-6 scroll-mt-20"
         >
           <div className="absolute inset-0 world-scrim pointer-events-none" aria-hidden="true" />
-          <div className="relative max-w-[88rem] mx-auto">
+          <div className="scroll-tilt-stage relative max-w-[88rem] mx-auto">
             <header className="mb-10 flex flex-col sm:flex-row sm:items-end justify-between gap-6">
               <div>
                 <p className="text-xs uppercase tracking-[0.22em] text-white/75 font-semibold mb-3">
@@ -230,7 +232,7 @@ export default function HomePage() {
         className="depth-scene relative py-24 sm:py-32 px-4 sm:px-6 border-t border-white/[0.05]"
       >
         <div className="absolute inset-0 world-scrim pointer-events-none" aria-hidden="true" />
-        <div className="relative max-w-5xl mx-auto text-center">
+        <div className="scroll-tilt-stage relative max-w-5xl mx-auto text-center">
           <p className="text-xs uppercase tracking-[0.22em] text-white/75 font-semibold mb-4">
             New on Surfaced
           </p>
@@ -281,7 +283,7 @@ export default function HomePage() {
           ============================================ */}
       <section className="depth-scene relative py-16 px-4 sm:px-6 border-t border-white/[0.05]">
         <div className="absolute inset-0 world-scrim pointer-events-none" aria-hidden="true" />
-        <div className="relative max-w-3xl mx-auto flex flex-col sm:flex-row items-center gap-6 floating-glass rounded-2xl p-8">
+        <div className="scroll-tilt-stage relative max-w-3xl mx-auto flex flex-col sm:flex-row items-center gap-6 floating-glass rounded-2xl p-8">
           <div className="w-20 h-20 rounded-full bg-gradient-to-br from-accent to-cyan flex items-center justify-center text-white text-2xl font-bold flex-shrink-0">
             {BYLINE.initials}
           </div>
@@ -468,7 +470,7 @@ function AlcoveSection({ alcove, items, index }: { alcove: Alcove; items: AnyIte
   return (
     <section
       data-world-scene={`alcove-${alcove.kind}`}
-      className="depth-scene relative min-h-[80vh] flex items-center overflow-hidden border-t border-white/[0.04]"
+      className="depth-scene no-scroll-tilt relative min-h-[80vh] flex items-center overflow-hidden border-t border-white/[0.04]"
     >
       {/* World scrim adapts to global world rather than having its own canvas */}
       <div className="absolute inset-0 world-scrim pointer-events-none" aria-hidden="true" />
@@ -479,7 +481,7 @@ function AlcoveSection({ alcove, items, index }: { alcove: Alcove; items: AnyIte
         }}
         aria-hidden="true"
       />
-      <div className="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 py-20 sm:py-28 w-full">
+      <div className="scroll-tilt-stage relative z-10 max-w-7xl mx-auto px-4 sm:px-6 py-20 sm:py-28 w-full">
         <div className={`flex flex-col ${flip ? "lg:flex-row-reverse" : "lg:flex-row"} gap-10 lg:gap-16 items-start`}>
           <div className="lg:w-1/3 lg:sticky lg:top-28">
             <p className="text-xs uppercase tracking-[0.25em] text-white/70 font-semibold mb-4">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -78,7 +78,7 @@ export default function HomePage() {
           ============================================ */}
       <section
         data-world-scene="hero"
-        className="relative min-h-screen -mt-16 pt-16 flex items-center overflow-hidden"
+        className="depth-scene relative min-h-screen -mt-16 pt-16 flex items-center overflow-hidden"
       >
         <div className="absolute inset-0 world-scrim pointer-events-none" aria-hidden="true" />
         <HeroParallax />
@@ -160,7 +160,7 @@ export default function HomePage() {
         <section
           id="today"
           data-world-scene="today"
-          className="relative py-20 sm:py-28 px-4 sm:px-6 scroll-mt-20"
+          className="depth-scene relative py-20 sm:py-28 px-4 sm:px-6 scroll-mt-20"
         >
           <div className="absolute inset-0 world-scrim pointer-events-none" aria-hidden="true" />
           <div className="relative max-w-[88rem] mx-auto">
@@ -186,12 +186,12 @@ export default function HomePage() {
               </Link>
             </header>
 
-            <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+            <div className="depth-grid grid grid-cols-1 lg:grid-cols-3 gap-6">
               <ScrollReveal className="lg:col-span-2">
                 <LeadCard item={leadStory} />
               </ScrollReveal>
 
-              <div className="flex flex-col gap-4">
+              <div className="depth-grid flex flex-col gap-4">
                 {supporting.slice(0, 3).map((item, idx) => (
                   <ScrollReveal key={item.slug} delay={idx * 80}>
                     <SupportingCard item={item} />
@@ -201,7 +201,7 @@ export default function HomePage() {
             </div>
 
             {supporting.length > 3 && (
-              <div className="mt-6 grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div className="depth-grid mt-6 grid grid-cols-1 sm:grid-cols-2 gap-4">
                 {supporting.slice(3).map((item, idx) => (
                   <ScrollReveal key={item.slug} delay={idx * 100}>
                     <SupportingCard item={item} compact />
@@ -227,7 +227,7 @@ export default function HomePage() {
           ============================================ */}
       <section
         data-world-scene="workflows"
-        className="relative py-24 sm:py-32 px-4 sm:px-6 border-t border-white/[0.05]"
+        className="depth-scene relative py-24 sm:py-32 px-4 sm:px-6 border-t border-white/[0.05]"
       >
         <div className="absolute inset-0 world-scrim pointer-events-none" aria-hidden="true" />
         <div className="relative max-w-5xl mx-auto text-center">
@@ -256,7 +256,7 @@ export default function HomePage() {
                 key={w.goal}
                 href={`/workflows#${encodeURIComponent(w.goal.toLowerCase().replace(/\s+/g, "-"))}`}
                 data-cursor="hover"
-                className="floating-glass group inline-flex items-center gap-2 px-5 py-3 rounded-full text-sm font-medium"
+                className="magnetic floating-glass group inline-flex items-center gap-2 px-5 py-3 rounded-full text-sm font-medium"
               >
                 <span className="text-accent">{w.icon}</span>
                 {w.goal}
@@ -268,7 +268,7 @@ export default function HomePage() {
             <Link
               href="/workflows"
               data-cursor="hover"
-              className="inline-flex items-center gap-2 px-7 py-3.5 rounded-xl bg-accent text-white text-sm font-semibold hover:bg-accent-hover transition-all"
+              className="magnetic inline-flex items-center gap-2 px-7 py-3.5 rounded-xl bg-accent text-white text-sm font-semibold hover:bg-accent-hover transition-all"
             >
               Explore all workflows →
             </Link>
@@ -279,7 +279,7 @@ export default function HomePage() {
       {/* ============================================
           BYLINE — E-E-A-T trust signal
           ============================================ */}
-      <section className="relative py-16 px-4 sm:px-6 border-t border-white/[0.05]">
+      <section className="depth-scene relative py-16 px-4 sm:px-6 border-t border-white/[0.05]">
         <div className="absolute inset-0 world-scrim pointer-events-none" aria-hidden="true" />
         <div className="relative max-w-3xl mx-auto flex flex-col sm:flex-row items-center gap-6 floating-glass rounded-2xl p-8">
           <div className="w-20 h-20 rounded-full bg-gradient-to-br from-accent to-cyan flex items-center justify-center text-white text-2xl font-bold flex-shrink-0">
@@ -337,10 +337,11 @@ function LeadCard({ item }: { item: AnyItem }) {
       as="article"
       className="floating-glass relative overflow-hidden rounded-3xl h-full"
       glowColor={glowRgb}
-      maxTilt={6}
-      hoverScale={1.015}
+      maxTilt={18}
+      hoverScale={1.04}
+      tiltDepth="strong"
     >
-      <div className="relative aspect-[16/10] overflow-hidden">
+      <div className="relative aspect-[16/10] overflow-hidden depth-layer-1">
         <ItemImage
           slug={item.slug}
           alt={title}
@@ -354,15 +355,15 @@ function LeadCard({ item }: { item: AnyItem }) {
         <div className="absolute inset-0 mix-blend-overlay opacity-70" style={{
           background: `radial-gradient(at 30% 80%, ${alcove.palette[0]}55, transparent 60%), radial-gradient(at 70% 20%, ${alcove.palette[1]}33, transparent 60%)`,
         }} />
-        <div className="absolute top-4 left-4 tilt-3d-pop">
+        <div className="absolute top-4 left-4 depth-layer-3">
           <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-white/15 backdrop-blur-md text-white text-[10px] font-bold uppercase tracking-[0.18em] border border-white/20">
             Lead Pick
           </span>
         </div>
       </div>
-      <div className="absolute inset-x-0 bottom-0 p-6 sm:p-8 tilt-3d-pop">
-        <CategoryBadge label={getItemCategory(item) || "Tool"} color="amber" className="mb-3" />
-        <Link href={`/item/${item.slug}`} data-cursor="hover" className="block group/title">
+      <div className="absolute inset-x-0 bottom-0 p-6 sm:p-8 depth-layer-2">
+        <CategoryBadge label={getItemCategory(item) || "Tool"} color="amber" className="mb-3 depth-layer-3" />
+        <Link href={`/item/${item.slug}`} data-cursor="hover" className="block group/title depth-layer-2">
           <h3 className="text-2xl sm:text-3xl font-bold text-white leading-tight tracking-tight group-hover/title:text-amber-200 transition-colors">
             {title}
           </h3>
@@ -370,11 +371,11 @@ function LeadCard({ item }: { item: AnyItem }) {
         <p className="mt-3 text-white/85 text-sm sm:text-base leading-relaxed line-clamp-2">
           {getItemExcerpt(item, 220)}
         </p>
-        <div className="mt-5 flex flex-wrap items-center gap-3">
+        <div className="mt-5 flex flex-wrap items-center gap-3 depth-layer-4">
           <Link
             href={`/item/${item.slug}`}
             data-cursor="hover"
-            className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-white text-black text-sm font-semibold hover:bg-white/90 transition-colors"
+            className="magnetic inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-white text-black text-sm font-semibold hover:bg-white/90 transition-colors"
           >
             Read the take
           </Link>
@@ -385,7 +386,7 @@ function LeadCard({ item }: { item: AnyItem }) {
               rel="noopener noreferrer"
               data-outbound="true"
               data-cursor="hover"
-              className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-white/10 backdrop-blur-md text-white text-sm font-medium border border-white/20 hover:bg-white/20 transition-colors"
+              className="magnetic inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-white/10 backdrop-blur-md text-white text-sm font-medium border border-white/20 hover:bg-white/20 transition-colors"
             >
               Visit {host} ↗
             </a>
@@ -409,15 +410,22 @@ function SupportingCard({ item, compact = false }: { item: AnyItem; compact?: bo
   const outbound = getOutbound(item);
   const host = getHost(outbound);
   const alcove = alcoveFromCategory(getItemCategory(item));
+  const glowRgb = hexToRgb(alcove.palette[0]);
 
   return (
-    <Link
-      href={`/item/${item.slug}`}
-      data-cursor="hover"
-      className="floating-glass group block relative overflow-hidden rounded-2xl"
+    <TiltCard3D
+      className="rounded-2xl h-full"
+      glowColor={glowRgb}
+      tiltDepth={compact ? "subtle" : "medium"}
+      maxTilt={14}
     >
+      <Link
+        href={`/item/${item.slug}`}
+        data-cursor="hover"
+        className="floating-glass group block relative overflow-hidden rounded-2xl h-full"
+      >
       <div className={`flex ${compact ? "flex-row" : "flex-col"}`}>
-        <div className={`relative overflow-hidden ${compact ? "w-32 flex-shrink-0" : "w-full aspect-[16/9]"}`}>
+        <div className={`depth-layer-1 relative overflow-hidden ${compact ? "w-32 flex-shrink-0" : "w-full aspect-[16/9]"}`}>
           <ItemImage
             slug={item.slug}
             alt={title}
@@ -431,8 +439,8 @@ function SupportingCard({ item, compact = false }: { item: AnyItem; compact?: bo
           }} />
         </div>
         <div className="p-4 flex flex-col flex-1 min-w-0">
-          <CategoryBadge label={getItemCategory(item) || "Tool"} color="amber" className="mb-2 self-start" />
-          <h3 className="text-sm font-semibold leading-snug group-hover:text-accent transition-colors line-clamp-2">
+          <CategoryBadge label={getItemCategory(item) || "Tool"} color="amber" className="depth-layer-3 mb-2 self-start" />
+          <h3 className="depth-layer-2 text-sm font-semibold leading-snug group-hover:text-accent transition-colors line-clamp-2">
             {title}
           </h3>
           {!compact && (
@@ -441,13 +449,14 @@ function SupportingCard({ item, compact = false }: { item: AnyItem; compact?: bo
             </p>
           )}
           {host && (
-            <p className="mt-auto pt-2 text-[10px] uppercase tracking-wider opacity-60">
+            <p className="depth-layer-4 mt-auto pt-2 text-[10px] uppercase tracking-wider opacity-60">
               {host}
             </p>
           )}
         </div>
       </div>
-    </Link>
+      </Link>
+    </TiltCard3D>
   );
 }
 
@@ -459,7 +468,7 @@ function AlcoveSection({ alcove, items, index }: { alcove: Alcove; items: AnyIte
   return (
     <section
       data-world-scene={`alcove-${alcove.kind}`}
-      className="relative min-h-[80vh] flex items-center overflow-hidden border-t border-white/[0.04]"
+      className="depth-scene relative min-h-[80vh] flex items-center overflow-hidden border-t border-white/[0.04]"
     >
       {/* World scrim adapts to global world rather than having its own canvas */}
       <div className="absolute inset-0 world-scrim pointer-events-none" aria-hidden="true" />
@@ -491,7 +500,7 @@ function AlcoveSection({ alcove, items, index }: { alcove: Alcove; items: AnyIte
             </Link>
           </div>
 
-          <div className="lg:w-2/3 grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div className="depth-grid lg:w-2/3 grid grid-cols-1 sm:grid-cols-2 gap-4">
             {items.map((item, i) => (
               <ScrollReveal key={item.slug} delay={i * 90}>
                 <AlcoveItemCard item={item} />
@@ -511,24 +520,25 @@ function AlcoveItemCard({ item }: { item: AnyItem }) {
     <TiltCard3D
       className="rounded-2xl h-full"
       glowColor={hexToRgb(alcove.palette[0])}
-      maxTilt={8}
-      hoverScale={1.02}
+      maxTilt={16}
+      hoverScale={1.035}
+      tiltDepth="medium"
     >
       <Link
         href={`/item/${item.slug}`}
         data-cursor="hover"
         className="alcove-card group block relative overflow-hidden rounded-2xl transition-all p-5 h-full"
       >
-        <div className="flex items-start gap-3 mb-3 tilt-3d-pop">
+        <div className="flex items-start gap-3 mb-3 depth-layer-3">
           <CategoryBadge label={getItemCategory(item) || ""} color="amber" />
         </div>
-        <h3 className="text-base sm:text-lg font-semibold leading-snug group-hover:text-amber-300 transition-colors line-clamp-2 tilt-3d-pop">
+        <h3 className="depth-layer-2 text-base sm:text-lg font-semibold leading-snug group-hover:text-amber-300 transition-colors line-clamp-2">
           {title}
         </h3>
         <p className="mt-2 text-sm alcove-card-muted leading-relaxed line-clamp-2">
           {getItemExcerpt(item, 130)}
         </p>
-        <div className="mt-4 text-[10px] uppercase tracking-wider alcove-card-faint inline-flex items-center gap-1">
+        <div className="depth-layer-4 mt-4 text-[10px] uppercase tracking-wider alcove-card-faint inline-flex items-center gap-1">
           Read the take <span className="group-hover:translate-x-0.5 transition-transform">→</span>
         </div>
       </Link>

--- a/src/app/tools/page.tsx
+++ b/src/app/tools/page.tsx
@@ -222,7 +222,7 @@ export default function ToolsPage() {
                     rel="noopener noreferrer"
                     data-outbound="true"
                     onClick={(e) => e.stopPropagation()}
-                    className="magnetic inline-flex items-center text-xs font-semibold text-rose-400 hover:text-rose-300 transition-colors"
+                    className="inline-flex items-center text-xs font-semibold text-rose-400 hover:text-rose-300 transition-colors"
                   >
                     Visit Site →
                   </a>

--- a/src/app/tools/page.tsx
+++ b/src/app/tools/page.tsx
@@ -14,7 +14,7 @@ import { LogoImage } from "@/components/ui/LogoImage";
 import { QuickViewModal } from "@/components/ui/QuickViewModal";
 import { AuroraBackground } from "@/components/ui/AuroraBackground";
 import { BlurText } from "@/components/ui/BlurText";
-import { TiltCard } from "@/components/ui/TiltCard";
+import { TiltCard3D } from "@/components/ui/TiltCard3D";
 import { EditorialTrustBar } from "@/components/ui/EditorialTrustBar";
 import { SourceTrailLink } from "@/components/ui/SourceTrailLink";
 import { filterLiveOutboundUrl } from "@/lib/dead-links";
@@ -70,7 +70,7 @@ export default function ToolsPage() {
         colorA="bg-rose-500/15"
         colorB="bg-pink-500/10"
         colorC="bg-red-500/6"
-        className="py-24 sm:py-32"
+        className="depth-scene py-24 sm:py-32"
       >
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 text-center">
           <p className="text-xs font-semibold uppercase tracking-[0.2em] text-rose-400 mb-4">
@@ -165,7 +165,7 @@ export default function ToolsPage() {
       </section>
 
       {/* ── Results Grid ──────────────────────────────────── */}
-      <section className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 pb-20">
+      <section className="depth-scene mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 pb-20">
         <p className="text-sm text-muted-foreground mb-6">
           Showing{" "}
           <span className="font-semibold text-foreground">
@@ -178,31 +178,31 @@ export default function ToolsPage() {
 
         {/* AD_ZONE: sidebar */}
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
+        <div className="depth-grid grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
           {paginatedItems.map((item, index) => (
             <ScrollReveal key={item.slug} delay={Math.min(index * 50, 800)} placeholder={<SkeletonCard />} className={index === 0 ? "sm:col-span-2 lg:col-span-2 xl:col-span-2" : ""}>
-              <TiltCard maxTilt={6} glowColor="0 8px 40px rgba(244,63,94,0.12), 0 0 0 1px rgba(244,63,94,0.08)" className="h-full">
+              <TiltCard3D maxTilt={18} glowColor="244, 63, 94" tiltDepth={index === 0 ? "strong" : "medium"} className="h-full rounded-2xl">
               <div className="official-card group relative rounded-2xl border border-border/60 bg-surface card-hover-glow transition-all h-full flex flex-col overflow-hidden">
-                <div className="overflow-hidden relative">
+                <div className="overflow-hidden relative depth-layer-1">
                   <ItemImage slug={item.slug} alt={item.toolName} aspectRatio="3/2" width={400} height={267} priority={index < 4} className="group-hover:scale-[1.03] transition-transform duration-500" />
                   {item.badge === "editors-pick" && (
-                    <span className="absolute top-2 left-2 z-10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider bg-amber-500/90 text-black rounded">
+                    <span className="absolute top-2 left-2 z-10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider bg-amber-500/90 text-black rounded depth-layer-3">
                       Editor&apos;s Pick
                     </span>
                   )}
                   <button
                     onClick={() => setQuickViewItem(item as AnyItem)}
-                    className="absolute inset-0 z-20 flex items-center justify-center bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity"
+                    className="magnetic absolute inset-0 z-20 flex items-center justify-center bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity"
                   >
                     <span className="px-3 py-1.5 bg-white text-black text-xs font-semibold rounded-full shadow">Quick View</span>
                   </button>
                 </div>
                 <div className="p-6 flex flex-col flex-1">
-                <div className="flex items-start justify-between gap-2 mb-3">
+                <div className="depth-layer-3 flex items-start justify-between gap-2 mb-3">
                   <CategoryBadge label={item.category} color="rose" />
                   <BookmarkButton slug={item.slug} />
                 </div>
-                <Link href={`/item/${item.slug}`} aria-label={`Read ${item.toolName}`} className="block mb-2">
+                <Link href={`/item/${item.slug}`} aria-label={`Read ${item.toolName}`} className="depth-layer-2 block mb-2">
                   <h2 className="text-base font-semibold text-foreground group-hover:text-rose-300 transition-colors line-clamp-2 flex items-center gap-1.5">
                     {hostForLiveUrl(item.websiteLink) && (
                       <LogoImage domain={hostForLiveUrl(item.websiteLink) || ""} />
@@ -214,7 +214,7 @@ export default function ToolsPage() {
                   {getItemExcerpt(item)}
                 </p>
                 {filterLiveOutboundUrl(item.websiteLink) && (
-                <div className="mt-auto flex flex-col gap-3">
+                <div className="depth-layer-4 mt-auto flex flex-col gap-3">
                   <SourceTrailLink href={filterLiveOutboundUrl(item.websiteLink)!} label="Official site" compact />
                   <a
                     href={filterLiveOutboundUrl(item.websiteLink)!}
@@ -222,7 +222,7 @@ export default function ToolsPage() {
                     rel="noopener noreferrer"
                     data-outbound="true"
                     onClick={(e) => e.stopPropagation()}
-                    className="inline-flex items-center text-xs font-semibold text-rose-400 hover:text-rose-300 transition-colors"
+                    className="magnetic inline-flex items-center text-xs font-semibold text-rose-400 hover:text-rose-300 transition-colors"
                   >
                     Visit Site →
                   </a>
@@ -230,7 +230,7 @@ export default function ToolsPage() {
                 )}
                 </div>
               </div>
-              </TiltCard>
+              </TiltCard3D>
             </ScrollReveal>
           ))}
         </div>

--- a/src/app/tools/page.tsx
+++ b/src/app/tools/page.tsx
@@ -72,7 +72,7 @@ export default function ToolsPage() {
         colorC="bg-red-500/6"
         className="depth-scene py-24 sm:py-32"
       >
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 text-center">
+        <div className="scroll-tilt-stage mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 text-center">
           <p className="text-xs font-semibold uppercase tracking-[0.2em] text-rose-400 mb-4">
             Tools
           </p>
@@ -166,22 +166,23 @@ export default function ToolsPage() {
 
       {/* ── Results Grid ──────────────────────────────────── */}
       <section className="depth-scene mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 pb-20">
-        <p className="text-sm text-muted-foreground mb-6">
-          Showing{" "}
-          <span className="font-semibold text-foreground">
-            {filtered.length === 0 ? 0 : (page - 1) * PER_PAGE + 1}–{Math.min(page * PER_PAGE, filtered.length)}
-          </span>{" "}
-          of{" "}
-          <span className="font-semibold text-foreground">{filtered.length}</span>{" "}
-          items
-        </p>
+        <div className="scroll-tilt-stage">
+          <p className="text-sm text-muted-foreground mb-6">
+            Showing{" "}
+            <span className="font-semibold text-foreground">
+              {filtered.length === 0 ? 0 : (page - 1) * PER_PAGE + 1}–{Math.min(page * PER_PAGE, filtered.length)}
+            </span>{" "}
+            of{" "}
+            <span className="font-semibold text-foreground">{filtered.length}</span>{" "}
+            items
+          </p>
 
-        {/* AD_ZONE: sidebar */}
+          {/* AD_ZONE: sidebar */}
 
-        <div className="depth-grid grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
-          {paginatedItems.map((item, index) => (
-            <ScrollReveal key={item.slug} delay={Math.min(index * 50, 800)} placeholder={<SkeletonCard />} className={index === 0 ? "sm:col-span-2 lg:col-span-2 xl:col-span-2" : ""}>
-              <TiltCard3D maxTilt={18} glowColor="244, 63, 94" tiltDepth={index === 0 ? "strong" : "medium"} className="h-full rounded-2xl">
+          <div className="depth-grid grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
+            {paginatedItems.map((item, index) => (
+              <ScrollReveal key={item.slug} delay={Math.min(index * 50, 800)} placeholder={<SkeletonCard />} className={index === 0 ? "sm:col-span-2 lg:col-span-2 xl:col-span-2" : ""}>
+                <TiltCard3D maxTilt={18} glowColor="244, 63, 94" tiltDepth={index === 0 ? "strong" : "medium"} className="h-full rounded-2xl">
               <div className="official-card group relative rounded-2xl border border-border/60 bg-surface card-hover-glow transition-all h-full flex flex-col overflow-hidden">
                 <div className="overflow-hidden relative depth-layer-1">
                   <ItemImage slug={item.slug} alt={item.toolName} aspectRatio="3/2" width={400} height={267} priority={index < 4} className="group-hover:scale-[1.03] transition-transform duration-500" />
@@ -230,36 +231,37 @@ export default function ToolsPage() {
                 )}
                 </div>
               </div>
-              </TiltCard3D>
-            </ScrollReveal>
-          ))}
+                </TiltCard3D>
+              </ScrollReveal>
+            ))}
+          </div>
+
+          {filtered.length === 0 && (
+            <div className="text-center py-16">
+              <p className="text-muted-foreground">No tools match your search.</p>
+            </div>
+          )}
+
+          {totalPages > 1 && (
+            <div className="flex items-center justify-center gap-2 mt-8">
+              <button
+                onClick={() => { setPage(p => Math.max(1, p - 1)); window.scrollTo({ top: 0, behavior: "smooth" }); }}
+                disabled={page === 1}
+                className="px-3 py-1.5 rounded-lg border border-border text-sm disabled:opacity-30 hover:bg-card transition-colors"
+              >
+                ← Previous
+              </button>
+              <span className="text-sm text-muted-foreground px-3">Page {page} of {totalPages}</span>
+              <button
+                onClick={() => { setPage(p => Math.min(totalPages, p + 1)); window.scrollTo({ top: 0, behavior: "smooth" }); }}
+                disabled={page === totalPages}
+                className="px-3 py-1.5 rounded-lg border border-border text-sm disabled:opacity-30 hover:bg-card transition-colors"
+              >
+                Next →
+              </button>
+            </div>
+          )}
         </div>
-
-        {filtered.length === 0 && (
-          <div className="text-center py-16">
-            <p className="text-muted-foreground">No tools match your search.</p>
-          </div>
-        )}
-
-        {totalPages > 1 && (
-          <div className="flex items-center justify-center gap-2 mt-8">
-            <button
-              onClick={() => { setPage(p => Math.max(1, p - 1)); window.scrollTo({ top: 0, behavior: "smooth" }); }}
-              disabled={page === 1}
-              className="px-3 py-1.5 rounded-lg border border-border text-sm disabled:opacity-30 hover:bg-card transition-colors"
-            >
-              ← Previous
-            </button>
-            <span className="text-sm text-muted-foreground px-3">Page {page} of {totalPages}</span>
-            <button
-              onClick={() => { setPage(p => Math.min(totalPages, p + 1)); window.scrollTo({ top: 0, behavior: "smooth" }); }}
-              disabled={page === totalPages}
-              className="px-3 py-1.5 rounded-lg border border-border text-sm disabled:opacity-30 hover:bg-card transition-colors"
-            >
-              Next →
-            </button>
-          </div>
-        )}
       </section>
 
       {/* ── Explore Another Category ─────────────────────── */}

--- a/src/app/tools/page.tsx
+++ b/src/app/tools/page.tsx
@@ -185,7 +185,7 @@ export default function ToolsPage() {
                 <TiltCard3D maxTilt={18} glowColor="244, 63, 94" tiltDepth={index === 0 ? "strong" : "medium"} className="h-full rounded-2xl">
               <div className="official-card group relative rounded-2xl border border-border/60 bg-surface card-hover-glow transition-all h-full flex flex-col overflow-hidden">
                 <div className="overflow-hidden relative depth-layer-1">
-                  <ItemImage slug={item.slug} alt={item.toolName} aspectRatio="3/2" width={400} height={267} priority={index < 4} className="group-hover:scale-[1.03] transition-transform duration-500" />
+                  <ItemImage slug={item.slug} alt={item.toolName} aspectRatio="3/2" width={400} height={267} priority={index < 4} className={`${index === 0 ? "hero-zoom-out " : ""}group-hover:scale-[1.03] transition-transform duration-500`} />
                   {item.badge === "editors-pick" && (
                     <span className="absolute top-2 left-2 z-10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider bg-amber-500/90 text-black rounded depth-layer-3">
                       Editor&apos;s Pick

--- a/src/app/trending/page.tsx
+++ b/src/app/trending/page.tsx
@@ -6,6 +6,7 @@ import { type AnyItem, getItemTitle, getItemExcerpt } from "@/lib/data";
 import { ItemImage } from "@/components/ui/ItemImage";
 import { alcoveByKind } from "@/lib/alcoves";
 import { AlcoveBackdrop } from "@/components/3d/AlcoveBackdrop";
+import { TiltCard3D } from "@/components/ui/TiltCard3D";
 
 export const metadata: Metadata = buildMetadata({
   title: "Trending Products — Archive",
@@ -22,7 +23,7 @@ export default function TrendingArchivePage() {
 
   return (
     <article>
-      <section className="relative min-h-[55vh] flex items-center overflow-hidden">
+      <section className="depth-scene relative min-h-[55vh] flex items-center overflow-hidden">
         <AlcoveBackdrop alcove={alcoveByKind("finance")} trackScroll />
         <div className="relative z-10 max-w-3xl mx-auto px-4 sm:px-6 py-24 sm:py-32">
           <p className="text-xs uppercase tracking-[0.22em] text-white/70 font-semibold mb-4">
@@ -51,18 +52,20 @@ export default function TrendingArchivePage() {
           <p className="text-sm text-muted-foreground mb-8">
             Showing the {items.length} most-recent of {(archiveData as AnyItem[]).filter((i) => i.type === "product").length} archived products.
           </p>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          <div className="depth-grid grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
             {items.map((item) => (
-              <Link key={item.slug} href={`/item/${item.slug}`} className="group block rounded-2xl border border-border bg-card overflow-hidden hover:border-accent/40 transition-all">
-                <div className="aspect-[16/10] overflow-hidden">
+              <TiltCard3D key={item.slug} className="rounded-2xl h-full" tiltDepth="medium" maxTilt={14} glowColor="251, 191, 36">
+              <Link href={`/item/${item.slug}`} className="group block rounded-2xl border border-border bg-card overflow-hidden hover:border-accent/40 transition-all h-full">
+                <div className="depth-layer-1 aspect-[16/10] overflow-hidden">
                   <ItemImage slug={item.slug} alt={getItemTitle(item)} aspectRatio="16/10" width={500} height={313} className="group-hover:scale-[1.03] transition-transform duration-500" />
                 </div>
                 <div className="p-5">
-                  <p className="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">Product</p>
-                  <h3 className="text-base font-semibold leading-snug group-hover:text-accent transition-colors line-clamp-2">{getItemTitle(item)}</h3>
+                  <p className="depth-layer-3 text-[10px] uppercase tracking-wider text-muted-foreground mb-2">Product</p>
+                  <h3 className="depth-layer-2 text-base font-semibold leading-snug group-hover:text-accent transition-colors line-clamp-2">{getItemTitle(item)}</h3>
                   <p className="mt-2 text-sm text-muted-foreground line-clamp-2 leading-relaxed">{getItemExcerpt(item, 140)}</p>
                 </div>
               </Link>
+              </TiltCard3D>
             ))}
           </div>
         </div>

--- a/src/app/workflows/page.tsx
+++ b/src/app/workflows/page.tsx
@@ -6,6 +6,7 @@ import { alcoveByKind } from "@/lib/alcoves";
 import { AlcoveBackdrop } from "@/components/3d/AlcoveBackdrop";
 import { hiddenGems, dailyTools, getItemTitle, type AnyItem } from "@/lib/data";
 import { BYLINE } from "@/lib/masthead";
+import { TiltCard3D } from "@/components/ui/TiltCard3D";
 
 export const metadata: Metadata = buildMetadata({
   title: "Workflows",
@@ -24,7 +25,7 @@ function lookupBySlug(slug?: string): AnyItem | undefined {
 export default function WorkflowsPage() {
   return (
     <>
-      <section className="relative min-h-[60vh] flex items-center overflow-hidden border-b border-white/[0.04]">
+      <section className="depth-scene relative min-h-[60vh] flex items-center overflow-hidden border-b border-white/[0.04]">
         <AlcoveBackdrop alcove={alcoveByKind("productivity")} trackScroll />
         <div className="relative z-10 max-w-5xl mx-auto px-4 sm:px-6 py-24 sm:py-32 text-center">
           <p className="text-xs uppercase tracking-[0.22em] text-white/70 font-semibold mb-4">
@@ -48,7 +49,7 @@ export default function WorkflowsPage() {
           <article
             id={wf.slug}
             key={wf.slug}
-            className="relative min-h-[80vh] flex items-center overflow-hidden border-t border-white/[0.04] scroll-mt-20"
+            className="depth-scene relative min-h-[80vh] flex items-center overflow-hidden border-t border-white/[0.04] scroll-mt-20"
           >
             <AlcoveBackdrop alcove={alcoveByKind(wf.alcove)} trackScroll />
             <div className="relative z-10 max-w-6xl mx-auto px-4 sm:px-6 py-20 w-full">
@@ -66,29 +67,33 @@ export default function WorkflowsPage() {
                   </p>
                 </div>
 
-                <ol className="lg:w-2/3 flex flex-col gap-3">
+                <ol className="depth-grid lg:w-2/3 flex flex-col gap-3">
                   {wf.steps.map((step, i) => {
                     const tool = lookupBySlug(step.toolSlug);
                     const toolName = tool ? getItemTitle(tool) : step.fallback ?? "Pick your own";
                     return (
-                      <li
+                      <TiltCard3D
+                        as="li"
                         key={i}
                         className="alcove-card relative p-5 rounded-2xl transition-colors"
+                        glowColor="168, 85, 247"
+                        tiltDepth="subtle"
+                        maxTilt={10}
                       >
                         <div className="flex items-start gap-4">
                           <div
-                            className="flex-shrink-0 w-9 h-9 rounded-full flex items-center justify-center font-bold text-sm"
+                            className="depth-layer-3 flex-shrink-0 w-9 h-9 rounded-full flex items-center justify-center font-bold text-sm"
                             style={{ background: `${wf.tint}33`, color: "#fff", border: `1px solid ${wf.tint}80` }}
                           >
                             {i + 1}
                           </div>
                           <div className="flex-1 min-w-0">
-                            <p className="text-[10px] uppercase tracking-[0.18em] alcove-card-faint mb-1">
+                            <p className="depth-layer-3 text-[10px] uppercase tracking-[0.18em] alcove-card-faint mb-1">
                               {step.action}
                             </p>
-                            <h3 className="text-lg sm:text-xl font-semibold">
+                            <h3 className="depth-layer-2 text-lg sm:text-xl font-semibold">
                               {tool ? (
-                                <Link href={`/item/${tool.slug}`} className="hover:underline">
+                                <Link href={`/item/${tool.slug}`} className="magnetic hover:underline">
                                   {toolName}
                                 </Link>
                               ) : (
@@ -102,7 +107,7 @@ export default function WorkflowsPage() {
                             )}
                           </div>
                         </div>
-                      </li>
+                      </TiltCard3D>
                     );
                   })}
                 </ol>
@@ -119,7 +124,7 @@ export default function WorkflowsPage() {
         </p>
         <Link
           href="/tools"
-          className="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-accent text-white text-sm font-semibold hover:bg-accent-hover transition-colors"
+          className="magnetic inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-accent text-white text-sm font-semibold hover:bg-accent-hover transition-colors"
         >
           Browse the full tool catalog →
         </Link>

--- a/src/components/3d/AmbientSoundscape.tsx
+++ b/src/components/3d/AmbientSoundscape.tsx
@@ -2,169 +2,449 @@
 
 import { useEffect, useRef, useState } from "react";
 import { usePathname } from "next/navigation";
-import { deriveWorldSeed } from "@/lib/world-seed";
+import { deriveWorldSeed, type WorldSeed } from "@/lib/world-seed";
+import {
+  ITEM_KEYFRAMES,
+  clamp01,
+  getWorldPhaseTelemetry,
+  type WorldPhaseTelemetry,
+} from "@/lib/world-phase";
 
 /**
- * Ambient soundscape — pure Web Audio synthesis (no audio files shipped).
- * Each route gets a unique chord built from the alcove palette's frequency
- * mapping. Crossfades smoothly when the user navigates.
+ * Scroll-locked layered soundscape.
  *
- * Strictly opt-in: silent until the user clicks the speaker toggle. Once
- * enabled, the preference persists in localStorage and follows the user
- * across routes. Toggle is always visible bottom-right.
- *
- * Accessibility: respects prefers-reduced-motion as a hint (still allows
- * opt-in), uses aria-pressed on the toggle, and starts at -22 LUFS so the
- * pad is felt more than heard.
+ * PR 1 for the spatial world upgrade: no shipped samples, no Tone.js, just six
+ * Web Audio synth layers that behave like short loops and crossfade by the
+ * same phase telemetry the item camera/morph uses. Default is silent; a user
+ * tap is required before an AudioContext exists.
  */
 const STORAGE_KEY = "surfaced.soundscape.enabled";
+const PHASE_EVENT = "surfaced:world-phase";
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+const ROUTE_LAYER_SCALE = 0.72;
 
-// Map alcove kinds to chord roots (Hz) and intervals (semitones)
-const PALETTE: Record<string, { root: number; intervals: number[]; lfoHz: number; lpHz: number }> = {
-  ai:            { root: 220.00, intervals: [0, 7, 14, 19], lfoHz: 0.07, lpHz: 360 },
-  writing:       { root: 174.61, intervals: [0, 5, 9, 12],  lfoHz: 0.05, lpHz: 420 },
-  design:        { root: 261.63, intervals: [0, 4, 7, 11],  lfoHz: 0.09, lpHz: 480 },
-  developer:     { root: 146.83, intervals: [0, 7, 10, 17], lfoHz: 0.06, lpHz: 320 },
-  productivity: { root: 196.00, intervals: [0, 5, 7, 12],  lfoHz: 0.05, lpHz: 380 },
-  research:      { root: 110.00, intervals: [0, 3, 7, 10],  lfoHz: 0.04, lpHz: 300 },
-  audio:         { root: 261.63, intervals: [0, 7, 12, 19], lfoHz: 0.08, lpHz: 500 },
-  finance:       { root: 130.81, intervals: [0, 4, 7, 11],  lfoHz: 0.05, lpHz: 340 },
-  social:        { root: 246.94, intervals: [0, 3, 7, 10],  lfoHz: 0.07, lpHz: 440 },
-  health:        { root: 174.61, intervals: [0, 5, 7, 12],  lfoHz: 0.04, lpHz: 360 },
-  entertainment: { root: 293.66, intervals: [0, 4, 7, 11],  lfoHz: 0.10, lpHz: 520 },
-  default:       { root: 196.00, intervals: [0, 5, 9, 12],  lfoHz: 0.06, lpHz: 400 },
-};
+type OscillatorKind = OscillatorType;
 
-interface ActiveVoice {
-  ctx: AudioContext;
-  out: GainNode;
+interface LayerSpec {
+  intervals: number[];
+  oscillator: OscillatorKind;
+  detuneSpread: number;
+  filterHz: number;
+  filterQ: number;
+  delayMs: number;
+  feedback: number;
+  lfoHz: number;
+  lfoDepth: number;
+  maxGain: number;
+}
+
+interface LayerVoice {
+  gain: GainNode;
+  filter: BiquadFilterNode;
   oscs: OscillatorNode[];
   lfo: OscillatorNode;
-  lp: BiquadFilterNode;
+}
+
+interface ActiveSoundscape {
+  ctx: AudioContext;
+  master: GainNode;
+  layers: LayerVoice[];
+  key: string;
+}
+
+const ROOTS: Record<string, number> = {
+  ai: 220.0,
+  writing: 174.61,
+  design: 261.63,
+  developer: 146.83,
+  productivity: 196.0,
+  research: 110.0,
+  audio: 261.63,
+  finance: 130.81,
+  social: 246.94,
+  health: 174.61,
+  entertainment: 293.66,
+  default: 196.0,
+};
+
+const LAYERS: LayerSpec[] = [
+  // Arrival: sparse sub-bass drone.
+  {
+    intervals: [-24, -12, 0],
+    oscillator: "sine",
+    detuneSpread: 3,
+    filterHz: 150,
+    filterQ: 0.55,
+    delayMs: 0,
+    feedback: 0,
+    lfoHz: 1 / 16,
+    lfoDepth: 28,
+    maxGain: 0.72,
+  },
+  // Recognition: bell-pad layer enters.
+  {
+    intervals: [0, 7, 12, 19],
+    oscillator: "triangle",
+    detuneSpread: 9,
+    filterHz: 520,
+    filterQ: 0.7,
+    delayMs: 180,
+    feedback: 0.18,
+    lfoHz: 1 / 12,
+    lfoDepth: 70,
+    maxGain: 0.58,
+  },
+  // Heart: full harmonic stack.
+  {
+    intervals: [-12, 0, 4, 7, 12, 16],
+    oscillator: "sawtooth",
+    detuneSpread: 14,
+    filterHz: 880,
+    filterQ: 0.85,
+    delayMs: 260,
+    feedback: 0.24,
+    lfoHz: 1 / 10,
+    lfoDepth: 120,
+    maxGain: 0.42,
+  },
+  // Inversion: cooled, reverbed pulse.
+  {
+    intervals: [-12, 0, 3, 10, 15],
+    oscillator: "triangle",
+    detuneSpread: 7,
+    filterHz: 340,
+    filterQ: 1.2,
+    delayMs: 420,
+    feedback: 0.34,
+    lfoHz: 0.75,
+    lfoDepth: 150,
+    maxGain: 0.48,
+  },
+  // Communion: choral pad / constellation.
+  {
+    intervals: [-7, 0, 5, 7, 12, 19],
+    oscillator: "sine",
+    detuneSpread: 18,
+    filterHz: 740,
+    filterQ: 0.65,
+    delayMs: 520,
+    feedback: 0.28,
+    lfoHz: 1 / 14,
+    lfoDepth: 95,
+    maxGain: 0.5,
+  },
+  // Departure: collapses to a single sine.
+  {
+    intervals: [-24],
+    oscillator: "sine",
+    detuneSpread: 0,
+    filterHz: 220,
+    filterQ: 0.45,
+    delayMs: 90,
+    feedback: 0.08,
+    lfoHz: 1 / 16,
+    lfoDepth: 18,
+    maxGain: 0.68,
+  },
+];
+
+function prefersReducedMotion(): boolean {
+  return typeof window !== "undefined" && window.matchMedia?.(REDUCED_MOTION_QUERY).matches === true;
+}
+
+function readScrollT(): number {
+  if (typeof window === "undefined") return 0;
+  const max = Math.max(1, document.documentElement.scrollHeight - window.innerHeight);
+  return clamp01(window.scrollY / max);
+}
+
+function currentWorldSeed(pathname: string | null): WorldSeed {
+  if (typeof document === "undefined") {
+    return deriveWorldSeed({ pathname: pathname || "/" });
+  }
+  const slug = document.body.dataset.itemSlug;
+  const category = document.body.dataset.itemCategory;
+  return deriveWorldSeed({ pathname: pathname || "/", slug, category });
+}
+
+function soundscapeKey(seed: WorldSeed): string {
+  return `${seed.scene}:${seed.key}:${seed.alcove.kind}`;
+}
+
+function note(root: number, semis: number): number {
+  return root * Math.pow(2, semis / 12);
+}
+
+function rootForSeed(seed: WorldSeed): number {
+  const base = ROOTS[seed.alcove.kind] ?? ROOTS.default;
+  return base * (0.96 + seed.hue * 0.08);
+}
+
+function startLayeredSoundscape(seed: WorldSeed): ActiveSoundscape {
+  type AnyWin = Window & typeof globalThis & { webkitAudioContext?: typeof AudioContext };
+  const AC: typeof AudioContext = window.AudioContext ?? (window as AnyWin).webkitAudioContext!;
+  const ctx = new AC({ latencyHint: "interactive" });
+  const master = ctx.createGain();
+  master.gain.value = 0;
+  master.connect(ctx.destination);
+
+  const root = rootForSeed(seed);
+  const layers = LAYERS.map((spec, layerIndex) => createLayer(ctx, master, root, spec, layerIndex, seed));
+  master.gain.setValueAtTime(0, ctx.currentTime);
+  master.gain.linearRampToValueAtTime(0.058, ctx.currentTime + 1.1);
+
+  return { ctx, master, layers, key: soundscapeKey(seed) };
+}
+
+function createLayer(
+  ctx: AudioContext,
+  master: GainNode,
+  root: number,
+  spec: LayerSpec,
+  layerIndex: number,
+  seed: WorldSeed
+): LayerVoice {
+  const gain = ctx.createGain();
+  gain.gain.value = 0;
+  gain.connect(master);
+
+  const filter = ctx.createBiquadFilter();
+  filter.type = layerIndex >= 3 ? "bandpass" : "lowpass";
+  filter.frequency.value = spec.filterHz;
+  filter.Q.value = spec.filterQ;
+
+  if (spec.delayMs > 0) {
+    const delay = ctx.createDelay(1.2);
+    const feedback = ctx.createGain();
+    delay.delayTime.value = spec.delayMs / 1000;
+    feedback.gain.value = spec.feedback;
+    filter.connect(delay);
+    delay.connect(feedback);
+    feedback.connect(delay);
+    delay.connect(gain);
+  }
+  filter.connect(gain);
+
+  const lfo = ctx.createOscillator();
+  const lfoGain = ctx.createGain();
+  lfo.frequency.value = spec.lfoHz;
+  lfoGain.gain.value = spec.lfoDepth;
+  lfo.connect(lfoGain);
+  lfoGain.connect(filter.frequency);
+  lfo.start();
+
+  const oscs = spec.intervals.map((semis, i) => {
+    const osc = ctx.createOscillator();
+    const voiceGain = ctx.createGain();
+    osc.type = spec.oscillator;
+    osc.frequency.value = note(root, semis);
+    osc.detune.value = (i - (spec.intervals.length - 1) / 2) * spec.detuneSpread + (seed.hue - 0.5) * 12;
+    voiceGain.gain.value = 1 / Math.max(1.8, spec.intervals.length);
+    osc.connect(voiceGain);
+    voiceGain.connect(filter);
+    osc.start();
+    return osc;
+  });
+
+  return { gain, filter, oscs, lfo };
+}
+
+function syncLayerGains(active: ActiveSoundscape, telemetry: WorldPhaseTelemetry): void {
+  const now = active.ctx.currentTime;
+  const fromPower = Math.cos(telemetry.mix * Math.PI * 0.5);
+  const toPower = Math.sin(telemetry.mix * Math.PI * 0.5);
+  const routeScale = telemetry.scene === "route" ? ROUTE_LAYER_SCALE : 1;
+  const masterTarget = (0.048 + telemetry.glow * 0.012) * routeScale;
+
+  active.master.gain.setTargetAtTime(masterTarget, now, 0.16);
+
+  active.layers.forEach((layer, index) => {
+    let power = 0;
+    if (index === telemetry.phaseIndex) power = fromPower;
+    if (index === telemetry.nextPhaseIndex) power = Math.max(power, toPower);
+    const target = power * LAYERS[index].maxGain;
+    layer.gain.gain.setTargetAtTime(target, now, 0.085);
+    layer.filter.frequency.setTargetAtTime(
+      LAYERS[index].filterHz * (0.82 + telemetry.glow * 0.22),
+      now,
+      0.18
+    );
+  });
+}
+
+function teardown(active: ActiveSoundscape | null): void {
+  if (!active) return;
+  try {
+    const now = active.ctx.currentTime;
+    active.master.gain.cancelScheduledValues(now);
+    active.master.gain.setValueAtTime(active.master.gain.value, now);
+    active.master.gain.linearRampToValueAtTime(0, now + 0.55);
+    window.setTimeout(() => {
+      try {
+        active.layers.forEach((layer) => {
+          layer.oscs.forEach((osc) => osc.stop());
+          layer.lfo.stop();
+        });
+      } catch {}
+      try {
+        active.ctx.close();
+      } catch {}
+    }, 650);
+  } catch {}
 }
 
 export function AmbientSoundscape() {
   const pathname = usePathname();
   const [enabled, setEnabled] = useState(false);
-  const voiceRef = useRef<ActiveVoice | null>(null);
-  const currentKey = useRef<string>("");
+  const [phaseLabel, setPhaseLabel] = useState("Arrival");
+  const [reducedMotion, setReducedMotion] = useState(false);
+  const voiceRef = useRef<ActiveSoundscape | null>(null);
+  const seedRef = useRef<WorldSeed | null>(null);
+  const telemetryRef = useRef<WorldPhaseTelemetry | null>(null);
+  const rafRef = useRef(0);
+  const labelRef = useRef("Arrival");
 
-  // Restore preference from localStorage
   useEffect(() => {
-    try {
-      if (localStorage.getItem(STORAGE_KEY) === "1") setEnabled(true);
-    } catch {}
+    const syncSeed = () => {
+      const seed = currentWorldSeed(pathname);
+      const key = soundscapeKey(seed);
+      const active = voiceRef.current;
+      seedRef.current = seed;
+
+      if (active && active.key !== key && !prefersReducedMotion()) {
+        teardown(active);
+        voiceRef.current = startLayeredSoundscape(seed);
+      }
+      schedulePhaseSync();
+    };
+
+    syncSeed();
+    window.addEventListener("surfaced:world-reseed", syncSeed);
+    return () => window.removeEventListener("surfaced:world-reseed", syncSeed);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pathname]);
+
+  useEffect(() => {
+    const schedule = () => schedulePhaseSync();
+    window.addEventListener("scroll", schedule, { passive: true });
+    window.addEventListener("resize", schedule, { passive: true });
+    schedule();
+    return () => {
+      window.removeEventListener("scroll", schedule);
+      window.removeEventListener("resize", schedule);
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Persist preference
   useEffect(() => {
-    try {
-      localStorage.setItem(STORAGE_KEY, enabled ? "1" : "0");
-    } catch {}
-  }, [enabled]);
+    const media = window.matchMedia?.(REDUCED_MOTION_QUERY);
+    if (!media) return;
+    const syncReducedMotion = () => {
+      const isReduced = media.matches;
+      setReducedMotion(isReduced);
+      if (isReduced && voiceRef.current) {
+        setEnabled(false);
+        teardown(voiceRef.current);
+        voiceRef.current = null;
+      }
+    };
+    syncReducedMotion();
+    media.addEventListener?.("change", syncReducedMotion);
+    return () => media.removeEventListener?.("change", syncReducedMotion);
+  }, []);
 
-  // Build / switch the chord when alcove changes
-  useEffect(() => {
-    if (!enabled) {
-      teardown();
+  useEffect(() => () => teardown(voiceRef.current), []);
+
+  function schedulePhaseSync() {
+    if (rafRef.current) return;
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = 0;
+      const seed = seedRef.current ?? currentWorldSeed(pathname);
+      const telemetry = getWorldPhaseTelemetry(seed, readScrollT());
+      telemetryRef.current = telemetry;
+      const active = voiceRef.current;
+      if (active) syncLayerGains(active, telemetry);
+      document.body.dataset.worldPhase = telemetry.id;
+      window.dispatchEvent(new CustomEvent(PHASE_EVENT, { detail: telemetry }));
+
+      if (labelRef.current !== telemetry.label) {
+        labelRef.current = telemetry.label;
+        setPhaseLabel(telemetry.label);
+      }
+    });
+  }
+
+  async function toggleSoundscape() {
+    if (enabled) {
+      setEnabled(false);
+      try {
+        localStorage.setItem(STORAGE_KEY, "0");
+      } catch {}
+      teardown(voiceRef.current);
+      voiceRef.current = null;
       return;
     }
-    const seed = deriveWorldSeed({ pathname: pathname || "/" });
-    const key = seed.alcove.kind;
-    if (key === currentKey.current && voiceRef.current) return;
-    currentKey.current = key;
 
-    teardown();
-    voiceRef.current = startVoice(PALETTE[key] || PALETTE.default);
+    if (prefersReducedMotion()) {
+      setPhaseLabel("Motion safe");
+      return;
+    }
 
-    return () => teardown();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [enabled, pathname]);
-
-  function teardown() {
-    const v = voiceRef.current;
-    if (!v) return;
+    const seed = currentWorldSeed(pathname);
+    seedRef.current = seed;
+    const active = startLayeredSoundscape(seed);
+    voiceRef.current = active;
+    if (active.ctx.state === "suspended") {
+      await active.ctx.resume();
+    }
+    const telemetry = getWorldPhaseTelemetry(seed, readScrollT());
+    telemetryRef.current = telemetry;
+    syncLayerGains(active, telemetry);
+    setEnabled(true);
     try {
-      const now = v.ctx.currentTime;
-      v.out.gain.cancelScheduledValues(now);
-      v.out.gain.setValueAtTime(v.out.gain.value, now);
-      v.out.gain.linearRampToValueAtTime(0, now + 0.9);
-      setTimeout(() => {
-        try { v.oscs.forEach((o) => o.stop()); v.lfo.stop(); } catch {}
-        try { v.ctx.close(); } catch {}
-      }, 1000);
+      localStorage.setItem(STORAGE_KEY, "1");
     } catch {}
-    voiceRef.current = null;
+    schedulePhaseSync();
   }
 
-  function startVoice(p: typeof PALETTE.default): ActiveVoice {
-    type AnyWin = Window & typeof globalThis & { webkitAudioContext?: typeof AudioContext };
-    const AC: typeof AudioContext = window.AudioContext ?? (window as AnyWin).webkitAudioContext!;
-    const ctx = new AC();
-    const out = ctx.createGain();
-    out.gain.value = 0;
-    out.connect(ctx.destination);
+  const disabledForMotion = reducedMotion;
+  const label = disabledForMotion
+    ? "Soundscape disabled while reduced motion is enabled"
+    : enabled
+      ? `Mute ${phaseLabel} soundscape`
+      : "Tap to enable scroll-locked soundscape";
 
-    out.gain.cancelScheduledValues(ctx.currentTime);
-    out.gain.setValueAtTime(0, ctx.currentTime);
-    out.gain.linearRampToValueAtTime(0.06, ctx.currentTime + 1.6);
-
-    const lp = ctx.createBiquadFilter();
-    lp.type = "lowpass";
-    lp.frequency.value = p.lpHz;
-    lp.Q.value = 0.7;
-
-    const oscs: OscillatorNode[] = p.intervals.map((semis, i) => {
-      const o = ctx.createOscillator();
-      o.type = i === 0 ? "sine" : i === 1 ? "triangle" : "sine";
-      o.frequency.value = p.root * Math.pow(2, semis / 12);
-      o.detune.value = (i - 1.5) * 6;
-      const g = ctx.createGain();
-      g.gain.value = i === 0 ? 0.7 : 0.45 - i * 0.06;
-      o.connect(g);
-      g.connect(lp);
-      o.start();
-      return o;
-    });
-
-    lp.connect(out);
-
-    const lfo = ctx.createOscillator();
-    const lfoGain = ctx.createGain();
-    lfo.frequency.value = p.lfoHz;
-    lfoGain.gain.value = 90;
-    lfo.connect(lfoGain);
-    lfoGain.connect(lp.frequency);
-    lfo.start();
-
-    return { ctx, out, oscs, lfo, lp };
-  }
-
-  // The toggle UI — fixed bottom-right
   return (
     <button
-      onClick={() => setEnabled((e) => !e)}
+      onClick={toggleSoundscape}
       aria-pressed={enabled}
-      aria-label={enabled ? "Mute ambient soundscape" : "Play ambient soundscape — adapts to each scene"}
-      title={enabled ? "Mute soundscape" : "Play ambient soundscape"}
-      className={`fixed bottom-6 right-6 z-[60] w-12 h-12 rounded-full backdrop-blur-md border transition-all flex items-center justify-center shadow-lg ${
+      aria-label={label}
+      title={label}
+      className={`fixed bottom-6 right-6 z-[60] h-12 rounded-full backdrop-blur-md border transition-all inline-flex items-center justify-center gap-2 px-3 sm:px-4 shadow-lg ${
         enabled
           ? "bg-accent text-white border-accent/40 shadow-[0_8px_30px_rgba(168,85,247,0.4)]"
           : "bg-black/40 text-white/70 border-white/15 hover:bg-black/60 hover:text-white"
       }`}
     >
       {enabled ? (
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
           <path d="M11 5L6 9H2v6h4l5 4V5z" />
           <path d="M19.07 4.93a10 10 0 010 14.14M15.54 8.46a5 5 0 010 7.07" />
         </svg>
       ) : (
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
           <path d="M11 5L6 9H2v6h4l5 4V5z" />
           <line x1="22" y1="9" x2="16" y2="15" />
           <line x1="16" y1="9" x2="22" y2="15" />
         </svg>
       )}
+      <span className="text-xs font-semibold leading-none">
+        {enabled ? phaseLabel : disabledForMotion ? "Motion safe" : "Tap for sound"}
+      </span>
+      <span className="sr-only">
+        {ITEM_KEYFRAMES.map((phase) => phase.label).join(", ")}
+      </span>
     </button>
   );
 }

--- a/src/components/3d/AmbientSoundscape.tsx
+++ b/src/components/3d/AmbientSoundscape.tsx
@@ -50,6 +50,7 @@ interface ActiveSoundscape {
   master: GainNode;
   layers: LayerVoice[];
   key: string;
+  hiddenMuted: boolean;
 }
 
 const ROOTS: Record<string, number> = {
@@ -193,7 +194,7 @@ function startLayeredSoundscape(seed: WorldSeed): ActiveSoundscape {
   master.gain.setValueAtTime(0, ctx.currentTime);
   master.gain.linearRampToValueAtTime(0.058, ctx.currentTime + 1.1);
 
-  return { ctx, master, layers, key: soundscapeKey(seed) };
+  return { ctx, master, layers, key: soundscapeKey(seed), hiddenMuted: document.hidden };
 }
 
 function createLayer(
@@ -254,7 +255,7 @@ function syncLayerGains(active: ActiveSoundscape, telemetry: WorldPhaseTelemetry
   const fromPower = Math.cos(telemetry.mix * Math.PI * 0.5);
   const toPower = Math.sin(telemetry.mix * Math.PI * 0.5);
   const routeScale = telemetry.scene === "route" ? ROUTE_LAYER_SCALE : 1;
-  const masterTarget = (0.048 + telemetry.glow * 0.012) * routeScale;
+  const masterTarget = active.hiddenMuted ? 0 : (0.048 + telemetry.glow * 0.012) * routeScale;
 
   active.master.gain.setTargetAtTime(masterTarget, now, 0.16);
 
@@ -270,6 +271,14 @@ function syncLayerGains(active: ActiveSoundscape, telemetry: WorldPhaseTelemetry
       0.18
     );
   });
+}
+
+function setHiddenMuted(active: ActiveSoundscape | null, hidden: boolean): void {
+  if (!active) return;
+  active.hiddenMuted = hidden;
+  const now = active.ctx.currentTime;
+  active.master.gain.cancelScheduledValues(now);
+  active.master.gain.setTargetAtTime(hidden ? 0 : active.master.gain.value, now, hidden ? 0.04 : 0.12);
 }
 
 function teardown(active: ActiveSoundscape | null): void {
@@ -334,6 +343,17 @@ export function AmbientSoundscape() {
       window.removeEventListener("resize", schedule);
       if (rafRef.current) cancelAnimationFrame(rafRef.current);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const syncVisibility = () => {
+      setHiddenMuted(voiceRef.current, document.hidden);
+      if (!document.hidden) schedulePhaseSync();
+    };
+    syncVisibility();
+    document.addEventListener("visibilitychange", syncVisibility);
+    return () => document.removeEventListener("visibilitychange", syncVisibility);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/components/3d/CursorCompanion.tsx
+++ b/src/components/3d/CursorCompanion.tsx
@@ -12,33 +12,73 @@ import { useEffect, useRef, useState } from "react";
 export function CursorCompanion() {
   const ref = useRef<HTMLDivElement>(null);
   const trailRef = useRef<HTMLDivElement>(null);
+  const shadowRef = useRef<HTMLDivElement>(null);
+  const echoRefs = useRef<Array<HTMLDivElement | null>>([]);
   const [enabled, setEnabled] = useState(false);
   const target = useRef({ x: 0, y: 0 });
   const current = useRef({ x: 0, y: 0 });
   const trail = useRef({ x: 0, y: 0 });
+  const shadow = useRef({ x: 0, y: 0 });
+  const lastPointer = useRef({ x: 0, y: 0, time: 0 });
+  const echoIndex = useRef(0);
+  const cardCenter = useRef<{ x: number; y: number } | null>(null);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
     if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
     // Touch devices don't have a meaningful cursor
     if (window.matchMedia?.("(pointer: coarse)").matches) return;
-    setEnabled(true);
+    const raf = requestAnimationFrame(() => setEnabled(true));
+    return () => cancelAnimationFrame(raf);
   }, []);
 
   useEffect(() => {
     if (!enabled) return;
 
     const onMove = (e: PointerEvent) => {
+      const now = performance.now();
+      const dt = Math.max(16, now - (lastPointer.current.time || now));
+      const speed = Math.hypot(e.clientX - lastPointer.current.x, e.clientY - lastPointer.current.y) / (dt / 1000);
       target.current.x = e.clientX;
       target.current.y = e.clientY;
+      lastPointer.current = { x: e.clientX, y: e.clientY, time: now };
+      ref.current?.classList.remove("companion-hidden");
+      trailRef.current?.classList.remove("companion-hidden");
+      shadowRef.current?.classList.remove("companion-hidden");
+
+      if (speed > 1200) {
+        for (let i = 0; i < 3; i++) {
+          const echo = echoRefs.current[echoIndex.current % echoRefs.current.length];
+          echoIndex.current++;
+          if (!echo) continue;
+          const offset = i * 4;
+          echo.style.transition = "none";
+          echo.style.opacity = "0.34";
+          echo.style.transform = `translate3d(${e.clientX - 8 - offset}px, ${e.clientY - 8}px, 0) scale(${1 - i * 0.12})`;
+          requestAnimationFrame(() => {
+            echo.style.transition = "opacity 280ms ease, transform 280ms ease";
+            echo.style.opacity = "0";
+            echo.style.transform = `translate3d(${e.clientX - 8 - offset}px, ${e.clientY - 8}px, 0) scale(0.35)`;
+          });
+        }
+      }
     };
 
     const onOver = (e: PointerEvent) => {
       const t = e.target as HTMLElement | null;
       if (!t) return;
       const interactive = t.closest("a, button, [role='button'], input, textarea, [data-cursor='hover']");
+      const tiltCard = t.closest<HTMLElement>(".tilt-3d");
       const orb = ref.current;
       if (!orb) return;
+      if (tiltCard) {
+        const rect = tiltCard.getBoundingClientRect();
+        cardCenter.current = { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+        orb.classList.add("companion-card");
+      } else {
+        cardCenter.current = null;
+        orb.classList.remove("companion-card");
+      }
       if (interactive) {
         orb.classList.add("companion-hover");
       } else {
@@ -48,25 +88,39 @@ export function CursorCompanion() {
 
     const onDown = () => ref.current?.classList.add("companion-press");
     const onUp = () => ref.current?.classList.remove("companion-press");
+    const onLeaveWindow = () => {
+      ref.current?.classList.add("companion-hidden");
+      trailRef.current?.classList.add("companion-hidden");
+      shadowRef.current?.classList.add("companion-hidden");
+    };
 
     window.addEventListener("pointermove", onMove, { passive: true });
     window.addEventListener("pointerover", onOver, { passive: true });
     window.addEventListener("pointerdown", onDown);
     window.addEventListener("pointerup", onUp);
+    window.addEventListener("pointerleave", onLeaveWindow);
+    window.addEventListener("blur", onLeaveWindow);
 
     let raf = 0;
     const tick = () => {
+      const attraction = cardCenter.current;
+      const tx = attraction ? target.current.x + (attraction.x - target.current.x) * 0.2 : target.current.x;
+      const ty = attraction ? target.current.y + (attraction.y - target.current.y) * 0.2 : target.current.y;
       // Soft spring toward cursor
-      current.current.x += (target.current.x - current.current.x) * 0.22;
-      current.current.y += (target.current.y - current.current.y) * 0.22;
+      current.current.x += (tx - current.current.x) * 0.22;
+      current.current.y += (ty - current.current.y) * 0.22;
       // Slower-following "trail" gives a sense of mass
       trail.current.x += (current.current.x - trail.current.x) * 0.10;
       trail.current.y += (current.current.y - trail.current.y) * 0.10;
+      shadow.current.x += (current.current.x - shadow.current.x) * 0.16;
+      shadow.current.y += (current.current.y - shadow.current.y) * 0.16;
 
       const o = ref.current;
       const t = trailRef.current;
+      const s = shadowRef.current;
       if (o) o.style.transform = `translate3d(${current.current.x - 14}px, ${current.current.y - 14}px, 0)`;
       if (t) t.style.transform = `translate3d(${trail.current.x - 28}px, ${trail.current.y - 28}px, 0)`;
+      if (s) s.style.transform = `translate3d(${shadow.current.x - 18}px, ${shadow.current.y + 16}px, 0)`;
       raf = requestAnimationFrame(tick);
     };
     raf = requestAnimationFrame(tick);
@@ -76,6 +130,8 @@ export function CursorCompanion() {
       window.removeEventListener("pointerover", onOver);
       window.removeEventListener("pointerdown", onDown);
       window.removeEventListener("pointerup", onUp);
+      window.removeEventListener("pointerleave", onLeaveWindow);
+      window.removeEventListener("blur", onLeaveWindow);
       cancelAnimationFrame(raf);
     };
   }, [enabled]);
@@ -84,7 +140,16 @@ export function CursorCompanion() {
 
   return (
     <>
+      <div ref={shadowRef} className="companion-shadow" aria-hidden="true" />
       <div ref={trailRef} className="companion-trail" aria-hidden="true" />
+      {Array.from({ length: 5 }).map((_, index) => (
+        <div
+          key={index}
+          ref={(el) => { echoRefs.current[index] = el; }}
+          className="companion-echo"
+          aria-hidden="true"
+        />
+      ))}
       <div ref={ref} className="companion-orb" aria-hidden="true" />
     </>
   );

--- a/src/components/3d/CursorCompanion.tsx
+++ b/src/components/3d/CursorCompanion.tsx
@@ -46,7 +46,7 @@ export function CursorCompanion() {
       trailRef.current?.classList.remove("companion-hidden");
       shadowRef.current?.classList.remove("companion-hidden");
 
-      if (speed > 1200) {
+      if (speed > 800) {
         for (let i = 0; i < 3; i++) {
           const echo = echoRefs.current[echoIndex.current % echoRefs.current.length];
           echoIndex.current++;

--- a/src/components/3d/GlobalWorld.tsx
+++ b/src/components/3d/GlobalWorld.tsx
@@ -85,6 +85,13 @@ export function GlobalWorld() {
   useEffect(() => {
     if (typeof window === "undefined") return;
     if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
+    const coarse = window.matchMedia?.("(pointer: coarse)").matches === true;
+    const narrow = window.innerWidth < 900;
+    const connection = (navigator as Navigator & { connection?: { saveData?: boolean } }).connection;
+    const lowData = connection && "saveData" in connection
+      ? connection.saveData === true
+      : false;
+    if (coarse || narrow || lowData) return;
     type IdleWindow = Window & {
       requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number;
     };

--- a/src/components/3d/GlobalWorld.tsx
+++ b/src/components/3d/GlobalWorld.tsx
@@ -29,6 +29,7 @@ export function GlobalWorld() {
   const [seed, setSeed] = useState(() => deriveWorldSeed({ pathname: pathname || "/" }));
   const [enabled, setEnabled] = useState(false);
   const [hidden, setHidden] = useState(false);
+  const [inViewport, setInViewport] = useState(true);
   const scrollTRef = useRef(0);
   const pointerRef = useRef({ x: 0, y: 0 });
   const [scrollT, setScrollT] = useState(0);
@@ -60,6 +61,27 @@ export function GlobalWorld() {
     const idle = (cb: () => void) =>
       w.requestIdleCallback ? w.requestIdleCallback(cb, { timeout: 1500 }) : window.setTimeout(cb, 800);
     idle(() => setEnabled(true));
+  }, []);
+
+  // Gate the persistent canvas with IntersectionObserver. It normally stays
+  // active because #main-content spans the reading surface, but it avoids a
+  // live WebGL renderer when the app shell is mounted offscreen in tests or
+  // embedded previews.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (!("IntersectionObserver" in window)) {
+      return;
+    }
+    const target = document.getElementById("main-content");
+    if (!target) {
+      return;
+    }
+    const observer = new IntersectionObserver(
+      ([entry]) => setInViewport(entry.isIntersecting),
+      { rootMargin: "240px 0px" }
+    );
+    observer.observe(target);
+    return () => observer.disconnect();
   }, []);
 
   // Scroll progress 0..1 (capped at scrollable height)
@@ -111,7 +133,7 @@ export function GlobalWorld() {
       className="fixed inset-0 pointer-events-none -z-10"
       style={{ background: fallback }}
     >
-      {enabled && !hidden && (
+      {enabled && !hidden && inViewport && (
         <WorldCanvas seed={seed} scrollT={scrollT} pointer={pointer} />
       )}
       {/* Scrim — keeps text readable against the lively backdrop */}

--- a/src/components/3d/GlobalWorld.tsx
+++ b/src/components/3d/GlobalWorld.tsx
@@ -129,7 +129,7 @@ export function GlobalWorld() {
         const dt = Math.max(16, now - (lastScrollRef.current.time || now));
         const dy = currentY - lastScrollRef.current.y;
         const velocity = Math.max(-60, Math.min(60, dy / (dt / 16.67)));
-        const tilt = Math.max(-2.5, Math.min(2.5, velocity * 0.04));
+        const tilt = Math.max(-1.5, Math.min(1.5, velocity * 0.04));
         lastScrollRef.current = { y: currentY, time: now };
         scrollTRef.current = t;
         setScrollT(t);

--- a/src/components/3d/GlobalWorld.tsx
+++ b/src/components/3d/GlobalWorld.tsx
@@ -7,6 +7,8 @@ import { deriveWorldSeed } from "@/lib/world-seed";
 
 const WorldCanvas = dynamic(() => import("./WorldCanvas"), { ssr: false });
 
+type WorldQuality = "full" | "lite";
+
 /**
  * GlobalWorld — the persistent 3D world that lives behind every route.
  *
@@ -32,8 +34,12 @@ export function GlobalWorld() {
   const [inViewport, setInViewport] = useState(true);
   const scrollTRef = useRef(0);
   const pointerRef = useRef({ x: 0, y: 0 });
+  const lastScrollRef = useRef({ y: 0, time: 0 });
+  const idleTimerRef = useRef<number | null>(null);
   const [scrollT, setScrollT] = useState(0);
+  const [scrollVelocity, setScrollVelocity] = useState(0);
   const [pointer, setPointer] = useState({ x: 0, y: 0 });
+  const [quality, setQuality] = useState<WorldQuality>("full");
 
   // Update seed on route change OR when the item page tells us it's seeded.
   // Reading [data-item-slug] from <body> lets item pages contribute their
@@ -49,6 +55,31 @@ export function GlobalWorld() {
     window.addEventListener("surfaced:world-reseed", reseed);
     return () => window.removeEventListener("surfaced:world-reseed", reseed);
   }, [pathname]);
+
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const path = pathname || "/";
+    const intensity = path.startsWith("/item/")
+      ? "0.7"
+      : ["/about", "/contact", "/privacy", "/terms", "/editorial-standards", "/affiliate-disclosure"].includes(path)
+        ? "0.4"
+        : path === "/"
+          ? "1"
+          : "0.82";
+    document.body.dataset.worldIntensity = intensity;
+  }, [pathname]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const coarse = window.matchMedia?.("(pointer: coarse)").matches === true;
+    const narrow = window.innerWidth < 900;
+    const connection = (navigator as Navigator & { connection?: { saveData?: boolean } }).connection;
+    const lowData = connection && "saveData" in connection
+      ? connection.saveData === true
+      : false;
+    const raf = requestAnimationFrame(() => setQuality(coarse || narrow || lowData ? "lite" : "full"));
+    return () => cancelAnimationFrame(raf);
+  }, []);
 
   // Defer WebGL boot until idle so the first paint is content
   useEffect(() => {
@@ -92,9 +123,26 @@ export function GlobalWorld() {
       raf = requestAnimationFrame(() => {
         raf = 0;
         const max = Math.max(1, document.documentElement.scrollHeight - window.innerHeight);
-        const t = Math.min(1, window.scrollY / max);
+        const now = performance.now();
+        const currentY = window.scrollY;
+        const t = Math.min(1, currentY / max);
+        const dt = Math.max(16, now - (lastScrollRef.current.time || now));
+        const dy = currentY - lastScrollRef.current.y;
+        const velocity = Math.max(-60, Math.min(60, dy / (dt / 16.67)));
+        const tilt = Math.max(-2.5, Math.min(2.5, velocity * 0.04));
+        lastScrollRef.current = { y: currentY, time: now };
         scrollTRef.current = t;
         setScrollT(t);
+        setScrollVelocity(velocity);
+        document.documentElement.style.setProperty("--scroll-t", String(t));
+        document.documentElement.style.setProperty("--scroll-vel", String(velocity));
+        document.documentElement.style.setProperty("--scroll-tilt", `${tilt}deg`);
+        if (idleTimerRef.current) window.clearTimeout(idleTimerRef.current);
+        idleTimerRef.current = window.setTimeout(() => {
+          setScrollVelocity(0);
+          document.documentElement.style.setProperty("--scroll-vel", "0");
+          document.documentElement.style.setProperty("--scroll-tilt", "0deg");
+        }, 300);
       });
     };
     window.addEventListener("scroll", handler, { passive: true });
@@ -102,6 +150,7 @@ export function GlobalWorld() {
     return () => {
       window.removeEventListener("scroll", handler);
       if (raf) cancelAnimationFrame(raf);
+      if (idleTimerRef.current) window.clearTimeout(idleTimerRef.current);
     };
   }, []);
 
@@ -112,6 +161,8 @@ export function GlobalWorld() {
       const y = -(((e.clientY / window.innerHeight) * 2 - 1));
       pointerRef.current = { x, y };
       setPointer({ x, y });
+      document.documentElement.style.setProperty("--pointer-x", String(x));
+      document.documentElement.style.setProperty("--pointer-y", String(y));
     };
     window.addEventListener("pointermove", handler, { passive: true });
     return () => window.removeEventListener("pointermove", handler);
@@ -126,6 +177,8 @@ export function GlobalWorld() {
 
   const shouldKeepDepartureAlive = seed.scene === "item" && scrollT > 0.9;
   const shouldRenderWorld = enabled && !hidden && (inViewport || shouldKeepDepartureAlive);
+  const legalPath = ["/about", "/contact", "/privacy", "/terms", "/editorial-standards", "/affiliate-disclosure"].includes(pathname || "/");
+  const worldIntensity = seed.scene === "item" ? 0.7 : legalPath ? 0.4 : pathname === "/" ? 1 : 0.82;
   const [a, b, c] = seed.alcove.palette;
   const fallback = `radial-gradient(at 28% 20%, ${a}55, transparent 60%), radial-gradient(at 72% 78%, ${b}33, transparent 65%), ${c}`;
 
@@ -133,10 +186,17 @@ export function GlobalWorld() {
     <div
       aria-hidden="true"
       className="fixed inset-0 pointer-events-none -z-10"
-      style={{ background: fallback }}
+      style={{ background: fallback, transition: "background 600ms cubic-bezier(0.65, 0, 0.35, 1)" }}
     >
       {shouldRenderWorld && (
-        <WorldCanvas seed={seed} scrollT={scrollT} pointer={pointer} />
+        <WorldCanvas
+          seed={seed}
+          scrollT={scrollT}
+          scrollVelocity={scrollVelocity}
+          pointer={pointer}
+          quality={quality}
+          worldIntensity={worldIntensity}
+        />
       )}
       {/* Scrim — keeps text readable against the lively backdrop */}
       <div

--- a/src/components/3d/GlobalWorld.tsx
+++ b/src/components/3d/GlobalWorld.tsx
@@ -118,6 +118,14 @@ export function GlobalWorld() {
   // Scroll progress 0..1 (capped at scrollable height)
   useEffect(() => {
     let raf = 0;
+    const depthScenes = Array.from(document.querySelectorAll<HTMLElement>(".depth-scene"));
+    const updateSectionProgress = () => {
+      depthScenes.forEach((scene) => {
+        const rect = scene.getBoundingClientRect();
+        const sectionT = Math.max(0, Math.min(1, -rect.top / Math.max(1, rect.height)));
+        scene.style.setProperty("--section-scroll-t", String(sectionT));
+      });
+    };
     const handler = () => {
       if (raf) return;
       raf = requestAnimationFrame(() => {
@@ -137,6 +145,7 @@ export function GlobalWorld() {
         document.documentElement.style.setProperty("--scroll-t", String(t));
         document.documentElement.style.setProperty("--scroll-vel", String(velocity));
         document.documentElement.style.setProperty("--scroll-tilt", `${tilt}deg`);
+        updateSectionProgress();
         if (idleTimerRef.current) window.clearTimeout(idleTimerRef.current);
         idleTimerRef.current = window.setTimeout(() => {
           setScrollVelocity(0);
@@ -146,13 +155,15 @@ export function GlobalWorld() {
       });
     };
     window.addEventListener("scroll", handler, { passive: true });
+    window.addEventListener("resize", handler);
     handler();
     return () => {
       window.removeEventListener("scroll", handler);
+      window.removeEventListener("resize", handler);
       if (raf) cancelAnimationFrame(raf);
       if (idleTimerRef.current) window.clearTimeout(idleTimerRef.current);
     };
-  }, []);
+  }, [pathname]);
 
   // Pointer parallax — normalize to -1..1
   useEffect(() => {

--- a/src/components/3d/GlobalWorld.tsx
+++ b/src/components/3d/GlobalWorld.tsx
@@ -119,11 +119,29 @@ export function GlobalWorld() {
   useEffect(() => {
     let raf = 0;
     const depthScenes = Array.from(document.querySelectorAll<HTMLElement>(".depth-scene"));
+    const depthSceneRatios = new Map<HTMLElement, number>();
+    const observer = "IntersectionObserver" in window
+      ? new IntersectionObserver(
+          (entries) => {
+            entries.forEach((entry) => {
+              depthSceneRatios.set(entry.target as HTMLElement, entry.intersectionRatio);
+            });
+            handler();
+          },
+          { threshold: [0, 0.2, 0.4, 0.6, 0.8, 1] }
+        )
+      : null;
     const updateSectionProgress = () => {
       depthScenes.forEach((scene) => {
         const rect = scene.getBoundingClientRect();
         const sectionT = Math.max(0, Math.min(1, -rect.top / Math.max(1, rect.height)));
+        const exitStart = window.innerHeight * 0.4;
+        const exitT = rect.bottom < exitStart
+          ? Math.max(0, Math.min(1, (exitStart - rect.bottom) / Math.max(1, rect.height * 0.4)))
+          : 0;
         scene.style.setProperty("--section-scroll-t", String(sectionT));
+        scene.style.setProperty("--section-exit-t", String(exitT));
+        scene.style.setProperty("--section-io-ratio", String(depthSceneRatios.get(scene) ?? 0));
       });
     };
     const handler = () => {
@@ -156,10 +174,12 @@ export function GlobalWorld() {
     };
     window.addEventListener("scroll", handler, { passive: true });
     window.addEventListener("resize", handler);
+    depthScenes.forEach((scene) => observer?.observe(scene));
     handler();
     return () => {
       window.removeEventListener("scroll", handler);
       window.removeEventListener("resize", handler);
+      observer?.disconnect();
       if (raf) cancelAnimationFrame(raf);
       if (idleTimerRef.current) window.clearTimeout(idleTimerRef.current);
     };

--- a/src/components/3d/GlobalWorld.tsx
+++ b/src/components/3d/GlobalWorld.tsx
@@ -124,6 +124,8 @@ export function GlobalWorld() {
     return () => document.removeEventListener("visibilitychange", handler);
   }, []);
 
+  const shouldKeepDepartureAlive = seed.scene === "item" && scrollT > 0.9;
+  const shouldRenderWorld = enabled && !hidden && (inViewport || shouldKeepDepartureAlive);
   const [a, b, c] = seed.alcove.palette;
   const fallback = `radial-gradient(at 28% 20%, ${a}55, transparent 60%), radial-gradient(at 72% 78%, ${b}33, transparent 65%), ${c}`;
 
@@ -133,7 +135,7 @@ export function GlobalWorld() {
       className="fixed inset-0 pointer-events-none -z-10"
       style={{ background: fallback }}
     >
-      {enabled && !hidden && inViewport && (
+      {shouldRenderWorld && (
         <WorldCanvas seed={seed} scrollT={scrollT} pointer={pointer} />
       )}
       {/* Scrim — keeps text readable against the lively backdrop */}

--- a/src/components/3d/WorldCanvas.tsx
+++ b/src/components/3d/WorldCanvas.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef } from "react";
+import { useMemo, useRef } from "react";
 import { Canvas, useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 import type { WorldSeed } from "@/lib/world-seed";
@@ -10,6 +10,237 @@ interface Props {
   seed: WorldSeed;
   scrollT: number;
   pointer: { x: number; y: number };
+}
+
+type ItemKeyframe = {
+  camera: [number, number, number];
+  lookAt: [number, number, number];
+  fov: number;
+  density: number;
+  objectScale: number;
+  objectY: number;
+  objectZ: number;
+  twist: number;
+  glow: number;
+};
+
+const ITEM_KEYFRAMES: ItemKeyframe[] = [
+  {
+    camera: [0, 0.15, 6.25],
+    lookAt: [0, -0.35, -2.1],
+    fov: 66,
+    density: 0.58,
+    objectScale: 1.0,
+    objectY: -0.42,
+    objectZ: -2.05,
+    twist: 0.22,
+    glow: 0.72,
+  },
+  {
+    camera: [0.95, 0.55, 5.45],
+    lookAt: [0.1, -0.2, -2.7],
+    fov: 61,
+    density: 0.86,
+    objectScale: 1.18,
+    objectY: -0.18,
+    objectZ: -2.65,
+    twist: 0.58,
+    glow: 0.9,
+  },
+  {
+    camera: [-1.15, 0.85, 4.75],
+    lookAt: [-0.1, -0.05, -3.25],
+    fov: 57,
+    density: 1.0,
+    objectScale: 0.92,
+    objectY: -0.02,
+    objectZ: -3.2,
+    twist: 1.08,
+    glow: 1.15,
+  },
+  {
+    camera: [1.35, -0.05, 4.2],
+    lookAt: [0, -0.18, -3.95],
+    fov: 54,
+    density: 0.74,
+    objectScale: 1.34,
+    objectY: -0.28,
+    objectZ: -3.85,
+    twist: 0.72,
+    glow: 0.96,
+  },
+  {
+    camera: [-0.55, 0.35, 3.72],
+    lookAt: [0.08, -0.32, -4.6],
+    fov: 50,
+    density: 0.96,
+    objectScale: 1.12,
+    objectY: -0.46,
+    objectZ: -4.45,
+    twist: 1.38,
+    glow: 1.22,
+  },
+  {
+    camera: [0.15, 0.08, 5.15],
+    lookAt: [0, -0.55, -5.05],
+    fov: 59,
+    density: 0.64,
+    objectScale: 0.82,
+    objectY: -0.62,
+    objectZ: -5.05,
+    twist: 0.36,
+    glow: 0.66,
+  },
+];
+
+const ITEM_MORPH_STOPS = ITEM_KEYFRAMES.length;
+
+function clamp01(value: number): number {
+  return Math.min(1, Math.max(0, value));
+}
+
+function smoothstep(value: number): number {
+  return value * value * (3 - 2 * value);
+}
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+function getItemPhase(scrollT: number) {
+  const scaled = clamp01(scrollT) * (ITEM_MORPH_STOPS - 1);
+  const index = Math.min(ITEM_MORPH_STOPS - 2, Math.floor(scaled));
+  const next = Math.min(ITEM_MORPH_STOPS - 1, index + 1);
+  return { index, next, t: smoothstep(scaled - index), raw: scaled };
+}
+
+function getItemSceneSnapshot(seed: WorldSeed, scrollT: number) {
+  const phase = getItemPhase(scrollT);
+  const from = ITEM_KEYFRAMES[phase.index];
+  const to = ITEM_KEYFRAMES[phase.next];
+  const side = seed.rngSeed % 2 === 0 ? 1 : -1;
+  const depth = 0.9 + seed.intensity * 0.18;
+  const cameraX = lerp(from.camera[0], to.camera[0], phase.t) * side;
+  const lookX = lerp(from.lookAt[0], to.lookAt[0], phase.t) * side * 0.45;
+  const heartbeat = 0.92 + Math.sin(phase.raw * Math.PI) * 0.08;
+
+  return {
+    cameraX,
+    cameraY: lerp(from.camera[1], to.camera[1], phase.t),
+    cameraZ: lerp(from.camera[2], to.camera[2], phase.t) * depth,
+    lookX,
+    lookY: lerp(from.lookAt[1], to.lookAt[1], phase.t),
+    lookZ: lerp(from.lookAt[2], to.lookAt[2], phase.t),
+    fov: lerp(from.fov, to.fov, phase.t),
+    density: lerp(from.density, to.density, phase.t) * heartbeat,
+    objectScale: lerp(from.objectScale, to.objectScale, phase.t),
+    objectY: lerp(from.objectY, to.objectY, phase.t),
+    objectZ: lerp(from.objectZ, to.objectZ, phase.t),
+    twist: lerp(from.twist, to.twist, phase.t),
+    glow: lerp(from.glow, to.glow, phase.t),
+  };
+}
+
+function signedNoise(seed: number, vertexIndex: number, channel: number): number {
+  const n = Math.sin((seed * 0.0001 + vertexIndex * 12.9898 + channel * 78.233) * 437.585);
+  return (n - Math.floor(n)) * 2 - 1;
+}
+
+function writeTarget(
+  target: Float32Array,
+  offset: number,
+  x: number,
+  y: number,
+  z: number
+) {
+  target[offset] = x;
+  target[offset + 1] = y;
+  target[offset + 2] = z;
+}
+
+function buildItemMorphTargets(
+  base: Float32Array,
+  seed: WorldSeed
+): Float32Array[] {
+  const targets = Array.from({ length: ITEM_MORPH_STOPS }, () => new Float32Array(base.length));
+  const motifBend: Record<string, number> = {
+    orbit: 0.32,
+    lattice: 0.12,
+    ripple: 0.42,
+    particles: 0.5,
+    prism: 0.22,
+    gem: 0.28,
+  };
+  const bend = motifBend[seed.alcove.motif] ?? 0.3;
+  const seedAngle = seed.hue * Math.PI * 2;
+
+  for (let i = 0; i < base.length; i += 3) {
+    const vertexIndex = i / 3;
+    const x = base[i];
+    const y = base[i + 1];
+    const z = base[i + 2];
+    const length = Math.hypot(x, y, z) || 1;
+    const nx = x / length;
+    const ny = y / length;
+    const nz = z / length;
+    const angle = Math.atan2(nz, nx);
+    const ring = Math.hypot(nx, nz);
+    const jitter = signedNoise(seed.rngSeed, vertexIndex, 1);
+    const jitterB = signedNoise(seed.rngSeed, vertexIndex, 2);
+    const facet = Math.sin(angle * 6 + seedAngle) * 0.08;
+
+    const compactRadius = 1.0 + jitter * 0.055 + facet;
+    writeTarget(targets[0], i, nx * compactRadius, ny * compactRadius, nz * compactRadius);
+
+    const apertureRadius = 1.42 + Math.sin(angle * 4 + seedAngle) * 0.13 + jitter * 0.04;
+    writeTarget(
+      targets[1],
+      i,
+      Math.cos(angle) * apertureRadius,
+      ny * 0.24 + jitterB * 0.045,
+      Math.sin(angle) * (apertureRadius * (0.58 + Math.abs(ny) * 0.18))
+    );
+
+    const helixTurn = angle + ny * (3.6 + bend * 2.4) + seedAngle * 0.35;
+    const helixRadius = 0.72 + ring * 0.45 + jitter * 0.08;
+    writeTarget(
+      targets[2],
+      i,
+      Math.cos(helixTurn) * helixRadius,
+      ny * 1.45,
+      Math.sin(helixTurn) * helixRadius
+    );
+
+    const gridStep = 2.8;
+    writeTarget(
+      targets[3],
+      i,
+      Math.round(nx * gridStep) / gridStep * 1.42 + jitter * 0.045,
+      Math.round(ny * gridStep) / gridStep * 1.15 + jitterB * 0.035,
+      Math.round(nz * gridStep) / gridStep * 1.42 + signedNoise(seed.rngSeed, vertexIndex, 3) * 0.045
+    );
+
+    const bloomRadius = 1.22 + Math.pow(Math.abs(Math.sin(angle * 3 + seedAngle)), 1.7) * 0.5 + jitter * 0.08;
+    writeTarget(
+      targets[4],
+      i,
+      nx * bloomRadius * (1 + bend * 0.25),
+      ny * bloomRadius * 0.86,
+      nz * bloomRadius
+    );
+
+    const shardRadius = (1 - Math.abs(ny)) * 0.78 + 0.12 + jitter * 0.035;
+    const shardAngle = angle + seedAngle * 0.2 + jitterB * 0.18;
+    writeTarget(
+      targets[5],
+      i,
+      Math.cos(shardAngle) * shardRadius,
+      ny * 1.65,
+      Math.sin(shardAngle) * shardRadius * (0.72 + bend * 0.3)
+    );
+  }
+
+  return targets;
 }
 
 /* ----- Shared shaders (one set, swap uniforms) ----- */
@@ -121,7 +352,10 @@ const NEBULA_FRAGMENT = /* glsl */ `
 /* ----- Particle field (sparse glowing dust) ----- */
 function ParticleField({ seed, scrollT }: { seed: WorldSeed; scrollT: number }) {
   const ref = useRef<THREE.Points>(null);
-  const count = Math.round(800 * seed.density);
+  const geometryRef = useRef<THREE.BufferGeometry>(null);
+  const materialRef = useRef<THREE.PointsMaterial>(null);
+  const isItemScene = seed.scene === "item";
+  const count = Math.round((isItemScene ? 1300 : 800) * seed.density);
   const baseColor = useMemo(() => new THREE.Color(seed.alcove.palette[0]), [seed.alcove.palette]);
   const accentColor = useMemo(() => new THREE.Color(seed.alcove.palette[1]), [seed.alcove.palette]);
 
@@ -158,17 +392,37 @@ function ParticleField({ seed, scrollT }: { seed: WorldSeed; scrollT: number }) 
     // Slow rotation + scroll-driven dolly along z
     p.rotation.y += delta * 0.018;
     p.rotation.x = Math.sin(state.clock.elapsedTime * 0.08) * 0.04;
-    p.position.z = -scrollT * 2.5;
+    p.position.z = isItemScene ? -scrollT * 5.2 : -scrollT * 2.5;
+
+    if (isItemScene) {
+      const frame = getItemSceneSnapshot(seed, scrollT);
+      const pulse = clamp01(frame.density);
+      const visibleCount = Math.max(140, Math.floor(count * (0.34 + pulse * 0.66)));
+      geometryRef.current?.setDrawRange(0, visibleCount);
+      if (materialRef.current) {
+        materialRef.current.opacity = 0.34 + pulse * 0.5;
+        materialRef.current.size = 0.065 + pulse * 0.09;
+      }
+    } else {
+      // Reset imperatives the item scene may have set on previous frames so
+      // route pages visited after an item don't inherit a clipped/dimmed field.
+      geometryRef.current?.setDrawRange(0, Infinity);
+      if (materialRef.current) {
+        materialRef.current.opacity = 0.85;
+        materialRef.current.size = 0.12;
+      }
+    }
   });
 
   return (
     <points ref={ref}>
-      <bufferGeometry>
+      <bufferGeometry ref={geometryRef}>
         <bufferAttribute attach="attributes-position" args={[positions, 3]} />
         <bufferAttribute attach="attributes-color" args={[colors, 3]} />
         <bufferAttribute attach="attributes-size" args={[sizes, 1]} />
       </bufferGeometry>
       <pointsMaterial
+        ref={materialRef}
         size={0.12}
         sizeAttenuation
         vertexColors
@@ -225,8 +479,77 @@ function NebulaBackground({ seed, scrollT, pointer }: Props) {
   );
 }
 
-/* ----- Floating focal object (per-item or per-route hero geometry) ----- */
-function FocalObject({ seed, scrollT }: { seed: WorldSeed; scrollT: number }) {
+/* ----- Morphing focal object: item pages get six deterministic keyframes ----- */
+function ItemFocalObject({ seed, scrollT }: { seed: WorldSeed; scrollT: number }) {
+  const meshRef = useRef<THREE.Mesh>(null);
+  const geometryRef = useRef<THREE.IcosahedronGeometry>(null);
+  const materialRef = useRef<THREE.MeshStandardMaterial>(null);
+  const targetsRef = useRef<Float32Array[] | null>(null);
+  const targetKeyRef = useRef("");
+  const basePositionsRef = useRef<Float32Array | null>(null);
+  const baseColor = useMemo(() => new THREE.Color(seed.alcove.palette[0]), [seed.alcove.palette]);
+  const emissiveColor = useMemo(() => new THREE.Color(seed.alcove.palette[1]), [seed.alcove.palette]);
+
+  useFrame((state, delta) => {
+    const mesh = meshRef.current;
+    const geometry = geometryRef.current;
+    if (!geometry) return;
+    if (!basePositionsRef.current) {
+      basePositionsRef.current = (geometry.attributes.position.array as Float32Array).slice();
+    }
+    if (!targetsRef.current || targetKeyRef.current !== seed.key) {
+      targetsRef.current = buildItemMorphTargets(basePositionsRef.current, seed);
+      targetKeyRef.current = seed.key;
+    }
+    const targets = targetsRef.current;
+    const position = geometry.attributes.position;
+    const array = position.array as Float32Array;
+    const phase = getItemPhase(scrollT);
+    const from = targets[phase.index];
+    const to = targets[phase.next];
+    const frame = getItemSceneSnapshot(seed, scrollT);
+
+    for (let i = 0; i < array.length; i++) {
+      array[i] = lerp(from[i], to[i], phase.t);
+    }
+    position.needsUpdate = true;
+    geometry.computeVertexNormals();
+
+    if (!mesh) return;
+    mesh.rotation.x += delta * (0.12 + frame.twist * 0.08);
+    mesh.rotation.y += delta * (0.22 + frame.twist * 0.12);
+    mesh.rotation.z = Math.sin(state.clock.elapsedTime * 0.22 + seed.hue * 6.28) * 0.12;
+    mesh.position.y = frame.objectY + Math.sin(state.clock.elapsedTime * 0.45) * 0.08;
+    mesh.position.z = frame.objectZ;
+    mesh.scale.setScalar(frame.objectScale * (1 + Math.sin(state.clock.elapsedTime * 0.65) * 0.035));
+
+    const material = materialRef.current;
+    if (material) {
+      material.opacity = 0.48 + frame.glow * 0.18;
+      material.emissiveIntensity = frame.glow;
+      material.wireframe = seed.alcove.motif === "lattice" || phase.index === 3;
+    }
+  });
+
+  return (
+    <mesh ref={meshRef} position={[0, -0.4, -2.2]}>
+      <icosahedronGeometry ref={geometryRef} args={[1, 2]} />
+      <meshStandardMaterial
+        ref={materialRef}
+        color={baseColor}
+        emissive={emissiveColor}
+        emissiveIntensity={0.85}
+        roughness={0.28}
+        metalness={0.72}
+        transparent
+        opacity={0.62}
+      />
+    </mesh>
+  );
+}
+
+/* ----- Floating focal object for non-item routes ----- */
+function RouteFocalObject({ seed, scrollT }: { seed: WorldSeed; scrollT: number }) {
   const meshRef = useRef<THREE.Mesh>(null);
 
   // Pick geometry detail level from alcove motif (radius, detail)
@@ -273,6 +596,52 @@ function FocalObject({ seed, scrollT }: { seed: WorldSeed; scrollT: number }) {
   );
 }
 
+/* ----- Floating focal object (per-item or per-route hero geometry) ----- */
+function FocalObject({ seed, scrollT }: { seed: WorldSeed; scrollT: number }) {
+  if (seed.scene === "item") {
+    return <ItemFocalObject seed={seed} scrollT={scrollT} />;
+  }
+  return <RouteFocalObject seed={seed} scrollT={scrollT} />;
+}
+
+/* ----- Camera rig — item pages dolly through the six reading keyframes ----- */
+function CameraRig({ seed, scrollT, pointer }: Props) {
+  const desired = useRef(new THREE.Vector3(0, 0, 6));
+  const target = useRef(new THREE.Vector3(0, -0.25, -2));
+
+  useFrame((state) => {
+    const camera = state.camera as THREE.PerspectiveCamera;
+
+    if (seed.scene === "item") {
+      const frame = getItemSceneSnapshot(seed, scrollT);
+      desired.current.set(
+        frame.cameraX + pointer.x * 0.16,
+        frame.cameraY + pointer.y * 0.08,
+        frame.cameraZ
+      );
+      target.current.set(
+        frame.lookX + pointer.x * 0.05,
+        frame.lookY + pointer.y * 0.03,
+        frame.lookZ
+      );
+      camera.position.lerp(desired.current, 0.065);
+      camera.lookAt(target.current);
+      camera.fov = lerp(camera.fov, frame.fov, 0.045);
+      camera.updateProjectionMatrix();
+      return;
+    }
+
+    desired.current.set(pointer.x * 0.12, pointer.y * 0.08, 6 - scrollT * 0.35);
+    target.current.set(0, -0.18, -2 - scrollT * 1.2);
+    camera.position.lerp(desired.current, 0.04);
+    camera.lookAt(target.current);
+    camera.fov = lerp(camera.fov, 65, 0.04);
+    camera.updateProjectionMatrix();
+  });
+
+  return null;
+}
+
 /* ----- Main canvas — composes everything ----- */
 export default function WorldCanvas({ seed, scrollT, pointer }: Props) {
   return (
@@ -286,6 +655,7 @@ export default function WorldCanvas({ seed, scrollT, pointer }: Props) {
       <ambientLight intensity={0.35} />
       <pointLight position={[3, 2, 4]} intensity={1.6} color={seed.alcove.palette[0]} />
       <pointLight position={[-4, -1, 3]} intensity={1.1} color={seed.alcove.palette[1]} />
+      <CameraRig seed={seed} scrollT={scrollT} pointer={pointer} />
       <NebulaBackground seed={seed} scrollT={scrollT} pointer={pointer} />
       <ParticleField seed={seed} scrollT={scrollT} />
       <FocalObject seed={seed} scrollT={scrollT} />

--- a/src/components/3d/WorldCanvas.tsx
+++ b/src/components/3d/WorldCanvas.tsx
@@ -287,12 +287,14 @@ const DRIFT_PARTICLE_FRAGMENT = /* glsl */ `
 `;
 
 /* ----- Particle field (sparse glowing dust) ----- */
-function ParticleField({ seed, scrollT }: { seed: WorldSeed; scrollT: number }) {
+function ParticleField({ seed, scrollT, quality }: { seed: WorldSeed; scrollT: number; quality: Props["quality"] }) {
   const ref = useRef<THREE.Points>(null);
   const geometryRef = useRef<THREE.BufferGeometry>(null);
   const materialRef = useRef<THREE.PointsMaterial>(null);
   const isItemScene = seed.scene === "item";
-  const count = Math.round((isItemScene ? 1300 : 800) * seed.density);
+  const count = quality === "lite"
+    ? Math.round((isItemScene ? 320 : 180) * seed.density)
+    : Math.round((isItemScene ? 1300 : 800) * seed.density);
   const baseColor = useMemo(() => new THREE.Color(seed.alcove.palette[0]), [seed.alcove.palette]);
   const accentColor = useMemo(() => new THREE.Color(seed.alcove.palette[1]), [seed.alcove.palette]);
 
@@ -852,6 +854,7 @@ export default function WorldCanvas(props: Props) {
       gl={{ antialias: false, alpha: false, powerPreference: "low-power" }}
       dpr={quality === "lite" ? [1, 1.25] : [1, 1.5]}
       frameloop="always"
+      performance={{ min: 0.4 }}
     >
       <ScenePalette seed={seed} />
       <ReactiveLights {...props} />
@@ -859,8 +862,8 @@ export default function WorldCanvas(props: Props) {
       <NebulaBackground {...props} />
       <GodRayShafts {...props} />
       <DepthDriftParticles {...props} />
-      <ParticleField seed={seed} scrollT={scrollT} />
-      {quality === "full" && <FocalBloomHalo seed={seed} scrollT={scrollT} worldIntensity={props.worldIntensity} />}
+      <ParticleField seed={seed} scrollT={scrollT} quality={quality} />
+      {quality === "full" && scrollT < 0.85 && <FocalBloomHalo seed={seed} scrollT={scrollT} worldIntensity={props.worldIntensity} />}
       <FocalObject seed={seed} scrollT={scrollT} />
     </Canvas>
   );

--- a/src/components/3d/WorldCanvas.tsx
+++ b/src/components/3d/WorldCanvas.tsx
@@ -5,6 +5,13 @@ import { Canvas, useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 import type { WorldSeed } from "@/lib/world-seed";
 import { makeRng } from "@/lib/world-seed";
+import {
+  ITEM_KEYFRAMES,
+  clamp01,
+  getItemPhase,
+  getItemSceneSnapshot,
+  lerp,
+} from "@/lib/world-phase";
 
 interface Props {
   seed: WorldSeed;
@@ -12,134 +19,7 @@ interface Props {
   pointer: { x: number; y: number };
 }
 
-type ItemKeyframe = {
-  camera: [number, number, number];
-  lookAt: [number, number, number];
-  fov: number;
-  density: number;
-  objectScale: number;
-  objectY: number;
-  objectZ: number;
-  twist: number;
-  glow: number;
-};
-
-const ITEM_KEYFRAMES: ItemKeyframe[] = [
-  {
-    camera: [0, 0.15, 6.25],
-    lookAt: [0, -0.35, -2.1],
-    fov: 66,
-    density: 0.58,
-    objectScale: 1.0,
-    objectY: -0.42,
-    objectZ: -2.05,
-    twist: 0.22,
-    glow: 0.72,
-  },
-  {
-    camera: [0.95, 0.55, 5.45],
-    lookAt: [0.1, -0.2, -2.7],
-    fov: 61,
-    density: 0.86,
-    objectScale: 1.18,
-    objectY: -0.18,
-    objectZ: -2.65,
-    twist: 0.58,
-    glow: 0.9,
-  },
-  {
-    camera: [-1.15, 0.85, 4.75],
-    lookAt: [-0.1, -0.05, -3.25],
-    fov: 57,
-    density: 1.0,
-    objectScale: 0.92,
-    objectY: -0.02,
-    objectZ: -3.2,
-    twist: 1.08,
-    glow: 1.15,
-  },
-  {
-    camera: [1.35, -0.05, 4.2],
-    lookAt: [0, -0.18, -3.95],
-    fov: 54,
-    density: 0.74,
-    objectScale: 1.34,
-    objectY: -0.28,
-    objectZ: -3.85,
-    twist: 0.72,
-    glow: 0.96,
-  },
-  {
-    camera: [-0.55, 0.35, 3.72],
-    lookAt: [0.08, -0.32, -4.6],
-    fov: 50,
-    density: 0.96,
-    objectScale: 1.12,
-    objectY: -0.46,
-    objectZ: -4.45,
-    twist: 1.38,
-    glow: 1.22,
-  },
-  {
-    camera: [0.15, 0.08, 5.15],
-    lookAt: [0, -0.55, -5.05],
-    fov: 59,
-    density: 0.64,
-    objectScale: 0.82,
-    objectY: -0.62,
-    objectZ: -5.05,
-    twist: 0.36,
-    glow: 0.66,
-  },
-];
-
 const ITEM_MORPH_STOPS = ITEM_KEYFRAMES.length;
-
-function clamp01(value: number): number {
-  return Math.min(1, Math.max(0, value));
-}
-
-function smoothstep(value: number): number {
-  return value * value * (3 - 2 * value);
-}
-
-function lerp(a: number, b: number, t: number): number {
-  return a + (b - a) * t;
-}
-
-function getItemPhase(scrollT: number) {
-  const scaled = clamp01(scrollT) * (ITEM_MORPH_STOPS - 1);
-  const index = Math.min(ITEM_MORPH_STOPS - 2, Math.floor(scaled));
-  const next = Math.min(ITEM_MORPH_STOPS - 1, index + 1);
-  return { index, next, t: smoothstep(scaled - index), raw: scaled };
-}
-
-function getItemSceneSnapshot(seed: WorldSeed, scrollT: number) {
-  const phase = getItemPhase(scrollT);
-  const from = ITEM_KEYFRAMES[phase.index];
-  const to = ITEM_KEYFRAMES[phase.next];
-  const side = seed.rngSeed % 2 === 0 ? 1 : -1;
-  const depth = 0.9 + seed.intensity * 0.18;
-  const cameraX = lerp(from.camera[0], to.camera[0], phase.t) * side;
-  const lookX = lerp(from.lookAt[0], to.lookAt[0], phase.t) * side * 0.45;
-  const heartbeat = 0.92 + Math.sin(phase.raw * Math.PI) * 0.08;
-
-  return {
-    cameraX,
-    cameraY: lerp(from.camera[1], to.camera[1], phase.t),
-    cameraZ: lerp(from.camera[2], to.camera[2], phase.t) * depth,
-    lookX,
-    lookY: lerp(from.lookAt[1], to.lookAt[1], phase.t),
-    lookZ: lerp(from.lookAt[2], to.lookAt[2], phase.t),
-    fov: lerp(from.fov, to.fov, phase.t),
-    density: lerp(from.density, to.density, phase.t) * heartbeat,
-    objectScale: lerp(from.objectScale, to.objectScale, phase.t),
-    objectY: lerp(from.objectY, to.objectY, phase.t),
-    objectZ: lerp(from.objectZ, to.objectZ, phase.t),
-    twist: lerp(from.twist, to.twist, phase.t),
-    glow: lerp(from.glow, to.glow, phase.t),
-  };
-}
 
 function signedNoise(seed: number, vertexIndex: number, channel: number): number {
   const n = Math.sin((seed * 0.0001 + vertexIndex * 12.9898 + channel * 78.233) * 437.585);

--- a/src/components/3d/WorldCanvas.tsx
+++ b/src/components/3d/WorldCanvas.tsx
@@ -16,7 +16,10 @@ import {
 interface Props {
   seed: WorldSeed;
   scrollT: number;
+  scrollVelocity: number;
   pointer: { x: number; y: number };
+  quality: "full" | "lite";
+  worldIntensity: number;
 }
 
 const ITEM_MORPH_STOPS = ITEM_KEYFRAMES.length;
@@ -143,6 +146,8 @@ const NEBULA_FRAGMENT = /* glsl */ `
   uniform vec3  uColorC;
   uniform vec2  uPointer;
   uniform float uHue;
+  uniform float uVelocity;
+  uniform float uIntensity;
 
   float hash(vec2 p) { return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453); }
   float noise(vec2 p) {
@@ -225,7 +230,59 @@ const NEBULA_FRAGMENT = /* glsl */ `
     // pushes toward color C (the deepest tone). Adds a "journey" feel.
     col = mix(col, hueShift(col, uScroll * 0.18), 0.35);
 
+    // Velocity-driven chromatic depth: subtle edge split that decays from JS.
+    float chroma = min(0.12, abs(uVelocity) * 0.006) * uIntensity;
+    float edge = smoothstep(0.35, 1.45, length(uv));
+    col.r += chroma * edge * 0.7;
+    col.b -= chroma * edge * 0.45;
+
+    // Cursor-centered vignette: darker at the edges, slightly brighter when
+    // the pointer comes home to center.
+    vec2 vignetteCenter = uPointer * 0.28;
+    float edgeVignette = smoothstep(0.45, 1.55, length(uv - vignetteCenter));
+    float centerBoost = (1.0 - smoothstep(0.0, 0.55, length(uPointer))) * 0.1;
+    col *= 1.0 - edgeVignette * (0.35 - centerBoost) * uIntensity;
+
     gl_FragColor = vec4(col, 1.0);
+  }
+`;
+
+const SHAFT_FRAGMENT = /* glsl */ `
+  precision highp float;
+  varying vec2 vUv;
+  uniform vec3 uColor;
+  uniform float uOpacity;
+  void main() {
+    float center = 1.0 - smoothstep(0.0, 0.48, abs(vUv.x - 0.5));
+    float vertical = smoothstep(0.0, 0.18, vUv.y) * (1.0 - smoothstep(0.72, 1.0, vUv.y));
+    float glow = pow(center, 1.75) * vertical;
+    gl_FragColor = vec4(uColor, glow * uOpacity);
+  }
+`;
+
+const DRIFT_PARTICLE_VERTEX = /* glsl */ `
+  attribute float aSize;
+  varying float vAlpha;
+  void main() {
+    vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
+    vAlpha = clamp(1.0 - abs(position.z) * 0.04, 0.35, 1.0);
+    gl_PointSize = aSize * (280.0 / max(1.0, -mvPosition.z));
+    gl_Position = projectionMatrix * mvPosition;
+  }
+`;
+
+const DRIFT_PARTICLE_FRAGMENT = /* glsl */ `
+  precision highp float;
+  uniform vec3 uColor;
+  uniform float uOpacity;
+  uniform float uChroma;
+  varying float vAlpha;
+  void main() {
+    vec2 uv = gl_PointCoord - 0.5;
+    float d = length(uv);
+    float disc = 1.0 - smoothstep(0.18, 0.5, d);
+    vec3 color = uColor + vec3(uChroma, 0.0, -uChroma * 0.65);
+    gl_FragColor = vec4(color, disc * uOpacity * vAlpha);
   }
 `;
 
@@ -316,9 +373,19 @@ function ParticleField({ seed, scrollT }: { seed: WorldSeed; scrollT: number }) 
 }
 
 /* ----- Nebula background plane (covers viewport) ----- */
-function NebulaBackground({ seed, scrollT, pointer }: Props) {
+function NebulaBackground({ seed, scrollT, scrollVelocity, pointer, worldIntensity }: Props) {
   const matRef = useRef<THREE.ShaderMaterial>(null);
   const pointerLerp = useRef(new THREE.Vector2(0, 0));
+  const targetColors = useMemo(() => {
+    const a = new THREE.Color(seed.alcove.palette[0]);
+    const b = new THREE.Color(seed.alcove.palette[1]);
+    const c = new THREE.Color(seed.alcove.palette[2]);
+    return [
+      new THREE.Vector3(a.r, a.g, a.b),
+      new THREE.Vector3(b.r, b.g, b.b),
+      new THREE.Vector3(c.r, c.g, c.b),
+    ] as const;
+  }, [seed.alcove.palette]);
 
   const uniforms = useMemo(() => {
     const a = new THREE.Color(seed.alcove.palette[0]);
@@ -332,14 +399,24 @@ function NebulaBackground({ seed, scrollT, pointer }: Props) {
       uColorC:  { value: new THREE.Vector3(c.r, c.g, c.b) },
       uPointer: { value: new THREE.Vector2(0, 0) },
       uHue:     { value: seed.hue },
+      uVelocity: { value: 0 },
+      uIntensity: { value: worldIntensity },
     };
-  }, [seed.alcove.palette, seed.hue]);
+    // Palette changes are lerped in useFrame so route transitions do not snap.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useFrame((_, delta) => {
     const m = matRef.current;
     if (!m) return;
     m.uniforms.uTime.value += delta;
     m.uniforms.uScroll.value = scrollT;
+    m.uniforms.uVelocity.value = scrollVelocity;
+    m.uniforms.uIntensity.value = worldIntensity;
+    m.uniforms.uHue.value = lerp(m.uniforms.uHue.value, seed.hue, Math.min(1, delta / 0.6));
+    (m.uniforms.uColorA.value as THREE.Vector3).lerp(targetColors[0], Math.min(1, delta / 0.6));
+    (m.uniforms.uColorB.value as THREE.Vector3).lerp(targetColors[1], Math.min(1, delta / 0.6));
+    (m.uniforms.uColorC.value as THREE.Vector3).lerp(targetColors[2], Math.min(1, delta / 0.6));
     pointerLerp.current.x += (pointer.x - pointerLerp.current.x) * 0.06;
     pointerLerp.current.y += (pointer.y - pointerLerp.current.y) * 0.06;
     (m.uniforms.uPointer.value as THREE.Vector2).copy(pointerLerp.current);
@@ -354,6 +431,250 @@ function NebulaBackground({ seed, scrollT, pointer }: Props) {
         vertexShader={NEBULA_VERTEX}
         fragmentShader={NEBULA_FRAGMENT}
         depthWrite={false}
+      />
+    </mesh>
+  );
+}
+
+function ScenePalette({ seed }: { seed: WorldSeed }) {
+  const current = useRef(new THREE.Color(seed.alcove.base));
+  const target = useMemo(() => new THREE.Color(seed.alcove.base), [seed.alcove.base]);
+
+  useFrame((state, delta) => {
+    current.current.lerp(target, Math.min(1, delta / 0.6));
+    state.scene.background = current.current;
+  });
+
+  return null;
+}
+
+function ReactiveLights({ seed, scrollT, pointer, worldIntensity }: Props) {
+  const keyRef = useRef<THREE.PointLight>(null);
+  const fillRef = useRef<THREE.PointLight>(null);
+  const rimRef = useRef<THREE.PointLight>(null);
+  const keyTarget = useMemo(() => new THREE.Color(seed.alcove.palette[0]), [seed.alcove.palette]);
+  const fillTarget = useMemo(() => new THREE.Color(seed.alcove.palette[1]), [seed.alcove.palette]);
+  const rimTarget = useMemo(() => new THREE.Color(seed.alcove.palette[2]), [seed.alcove.palette]);
+
+  useFrame((_, delta) => {
+    const key = keyRef.current;
+    const fill = fillRef.current;
+    const rim = rimRef.current;
+    if (key) {
+      key.color.lerp(keyTarget, Math.min(1, delta / 0.6));
+      key.position.lerp(new THREE.Vector3(2.6 + pointer.x * 0.9, 2.1 + pointer.y * 0.35, 3.3 - scrollT), 0.045);
+      key.intensity = lerp(key.intensity, (1.45 + scrollT * 0.55) * worldIntensity, 0.05);
+    }
+    if (fill) {
+      fill.color.lerp(fillTarget, Math.min(1, delta / 0.6));
+      fill.position.lerp(new THREE.Vector3(-3.6 + pointer.x * 0.45, -1.2 + pointer.y * 0.25, 2.8), 0.04);
+      fill.intensity = lerp(fill.intensity, (0.82 + Math.sin(scrollT * Math.PI) * 0.42) * worldIntensity, 0.05);
+    }
+    if (rim) {
+      rim.color.lerp(rimTarget, Math.min(1, delta / 0.6));
+      rim.position.lerp(new THREE.Vector3(pointer.x * 1.4, 1.7 + pointer.y * 0.45, -3.8), 0.05);
+      rim.intensity = lerp(rim.intensity, (0.7 + scrollT * 0.6) * worldIntensity, 0.04);
+    }
+  });
+
+  return (
+    <>
+      <ambientLight intensity={0.22 * worldIntensity} />
+      <pointLight ref={keyRef} position={[3, 2, 4]} intensity={1.4} color={seed.alcove.palette[0]} />
+      <pointLight ref={fillRef} position={[-4, -1, 3]} intensity={0.9} color={seed.alcove.palette[1]} />
+      <pointLight ref={rimRef} position={[0, 2, -4]} intensity={0.7} color={seed.alcove.palette[2]} />
+    </>
+  );
+}
+
+function GodRayBeam({
+  seed,
+  pointer,
+  scrollT,
+  worldIntensity,
+  index,
+  x,
+  y,
+  z,
+  rotation,
+  width,
+}: Props & { index: number; x: number; y: number; z: number; rotation: number; width: number }) {
+  const meshRef = useRef<THREE.Mesh>(null);
+  const matRef = useRef<THREE.ShaderMaterial>(null);
+  const sun = useRef(new THREE.Vector3(0, 0.7, -2));
+  const targetColor = useMemo(() => new THREE.Color(seed.alcove.palette[index % seed.alcove.palette.length]), [index, seed.alcove.palette]);
+  const uniforms = useMemo(() => ({
+    uColor: { value: targetColor.clone() },
+    uOpacity: { value: 0 },
+  }), [targetColor]);
+
+  useFrame((state, delta) => {
+    const mesh = meshRef.current;
+    const mat = matRef.current;
+    sun.current.lerp(new THREE.Vector3(pointer.x * 0.4, 0.7 + pointer.y * 0.2, -2), 0.025);
+    if (mesh) {
+      mesh.position.x = x + sun.current.x * (0.8 + index * 0.12);
+      mesh.position.y = y + Math.sin(state.clock.elapsedTime * 0.18 + index) * 0.12 + sun.current.y * 0.18;
+      mesh.position.z = z;
+      mesh.rotation.z = rotation + pointer.x * 0.08 + Math.sin(state.clock.elapsedTime * 0.08 + index) * 0.035;
+    }
+    if (mat) {
+      (mat.uniforms.uColor.value as THREE.Color).lerp(targetColor, Math.min(1, delta / 0.6));
+      mat.uniforms.uOpacity.value = (0.055 + scrollT * 0.08) * worldIntensity;
+    }
+  });
+
+  return (
+    <mesh ref={meshRef} position={[x, y, z]} rotation={[0, 0, rotation]}>
+      <planeGeometry args={[width, 7.2]} />
+      <shaderMaterial
+        ref={matRef}
+        uniforms={uniforms}
+        vertexShader={NEBULA_VERTEX}
+        fragmentShader={SHAFT_FRAGMENT}
+        transparent
+        depthWrite={false}
+        blending={THREE.AdditiveBlending}
+        side={THREE.DoubleSide}
+      />
+    </mesh>
+  );
+}
+
+function GodRayShafts(props: Props) {
+  const beams = useMemo(() => [
+    { x: -1.9, y: 0.25, z: -4.8, rotation: -0.28, width: 0.8 },
+    { x: -0.7, y: 0.45, z: -4.2, rotation: -0.16, width: 0.55 },
+    { x: 0.5, y: 0.32, z: -4.5, rotation: 0.08, width: 0.7 },
+    { x: 1.7, y: 0.12, z: -5.2, rotation: 0.22, width: 0.65 },
+  ], []);
+
+  if (props.quality === "lite") return null;
+
+  return (
+    <>
+      {beams.map((beam, index) => (
+        <GodRayBeam key={index} {...props} {...beam} index={index} />
+      ))}
+    </>
+  );
+}
+
+function DriftPlane({
+  seed,
+  pointer,
+  scrollVelocity,
+  worldIntensity,
+  plane,
+  count,
+  z,
+}: Props & { plane: number; count: number; z: number }) {
+  const pointsRef = useRef<THREE.Points>(null);
+  const matRef = useRef<THREE.ShaderMaterial>(null);
+  const colorTarget = useMemo(() => new THREE.Color(seed.alcove.palette[plane % seed.alcove.palette.length]), [plane, seed.alcove.palette]);
+  const { positions, sizes } = useMemo(() => {
+    const rng = makeRng(seed.rngSeed + plane * 101);
+    const pos = new Float32Array(count * 3);
+    const sz = new Float32Array(count);
+    for (let i = 0; i < count; i++) {
+      pos[i * 3] = (rng() - 0.5) * (11 + plane * 2);
+      pos[i * 3 + 1] = (rng() - 0.5) * (5.8 + plane);
+      pos[i * 3 + 2] = (rng() - 0.5) * 0.7;
+      sz[i] = 6 + rng() * 6;
+    }
+    return { positions: pos, sizes: sz };
+  }, [count, plane, seed.rngSeed]);
+  const uniforms = useMemo(() => ({
+    uColor: { value: colorTarget.clone() },
+    uOpacity: { value: 0.18 },
+    uChroma: { value: 0 },
+  }), [colorTarget]);
+
+  useFrame((state, delta) => {
+    const p = pointsRef.current;
+    const mat = matRef.current;
+    const depth = Math.abs(z) / 8;
+    if (p) {
+      p.position.x = pointer.x * depth * 0.65;
+      p.position.y = pointer.y * depth * 0.28;
+      p.position.z = z + Math.sin(state.clock.elapsedTime * 0.12 + plane) * 0.18;
+      p.rotation.z += delta * (0.006 + plane * 0.002);
+    }
+    if (mat) {
+      (mat.uniforms.uColor.value as THREE.Color).lerp(colorTarget, Math.min(1, delta / 0.6));
+      mat.uniforms.uOpacity.value = (0.11 + plane * 0.04) * worldIntensity;
+      mat.uniforms.uChroma.value = plane === 0 ? Math.min(0.09, Math.abs(scrollVelocity) * 0.003) : 0;
+    }
+  });
+
+  return (
+    <points ref={pointsRef}>
+      <bufferGeometry>
+        <bufferAttribute attach="attributes-position" args={[positions, 3]} />
+        <bufferAttribute attach="attributes-aSize" args={[sizes, 1]} />
+      </bufferGeometry>
+      <shaderMaterial
+        ref={matRef}
+        uniforms={uniforms}
+        vertexShader={DRIFT_PARTICLE_VERTEX}
+        fragmentShader={DRIFT_PARTICLE_FRAGMENT}
+        transparent
+        depthWrite={false}
+        blending={THREE.AdditiveBlending}
+      />
+    </points>
+  );
+}
+
+function DepthDriftParticles(props: Props) {
+  const counts = props.quality === "lite"
+    ? [{ plane: 1, count: 24, z: -4 }]
+    : [
+        { plane: 0, count: 24, z: -8 },
+        { plane: 1, count: 32, z: -4 },
+        { plane: 2, count: 16, z: -1 },
+      ];
+
+  return (
+    <>
+      {counts.map((cfg) => (
+        <DriftPlane key={cfg.plane} {...props} {...cfg} />
+      ))}
+    </>
+  );
+}
+
+function FocalBloomHalo({ seed, scrollT, worldIntensity }: { seed: WorldSeed; scrollT: number; worldIntensity: number }) {
+  const meshRef = useRef<THREE.Mesh>(null);
+  const matRef = useRef<THREE.MeshBasicMaterial>(null);
+  const colorTarget = useMemo(() => new THREE.Color(seed.alcove.palette[1]), [seed.alcove.palette]);
+
+  useFrame((state) => {
+    const mesh = meshRef.current;
+    const mat = matRef.current;
+    const frame = seed.scene === "item" ? getItemSceneSnapshot(seed, scrollT) : null;
+    if (mesh) {
+      mesh.position.y = frame ? frame.objectY : -0.5 + Math.sin(state.clock.elapsedTime * 0.4) * 0.25;
+      mesh.position.z = frame ? frame.objectZ : -2 - scrollT * 4;
+      const scale = (frame ? frame.objectScale : 1) * (1.9 + Math.sin(state.clock.elapsedTime * 0.5) * 0.08);
+      mesh.scale.setScalar(scale);
+    }
+    if (mat) {
+      mat.color.lerp(colorTarget, 0.035);
+      mat.opacity = (seed.scene === "item" ? 0.16 : 0.12) * worldIntensity;
+    }
+  });
+
+  return (
+    <mesh ref={meshRef} position={[0, -0.5, -2]}>
+      <icosahedronGeometry args={[1, 1]} />
+      <meshBasicMaterial
+        ref={matRef}
+        color={seed.alcove.palette[1]}
+        transparent
+        opacity={0.14}
+        depthWrite={false}
+        blending={THREE.AdditiveBlending}
       />
     </mesh>
   );
@@ -523,21 +844,23 @@ function CameraRig({ seed, scrollT, pointer }: Props) {
 }
 
 /* ----- Main canvas — composes everything ----- */
-export default function WorldCanvas({ seed, scrollT, pointer }: Props) {
+export default function WorldCanvas(props: Props) {
+  const { seed, scrollT, quality } = props;
   return (
     <Canvas
       camera={{ position: [0, 0, 6], fov: 65 }}
       gl={{ antialias: false, alpha: false, powerPreference: "low-power" }}
-      dpr={[1, 1.5]}
+      dpr={quality === "lite" ? [1, 1.25] : [1, 1.5]}
       frameloop="always"
     >
-      <color attach="background" args={[seed.alcove.base]} />
-      <ambientLight intensity={0.35} />
-      <pointLight position={[3, 2, 4]} intensity={1.6} color={seed.alcove.palette[0]} />
-      <pointLight position={[-4, -1, 3]} intensity={1.1} color={seed.alcove.palette[1]} />
-      <CameraRig seed={seed} scrollT={scrollT} pointer={pointer} />
-      <NebulaBackground seed={seed} scrollT={scrollT} pointer={pointer} />
+      <ScenePalette seed={seed} />
+      <ReactiveLights {...props} />
+      <CameraRig {...props} />
+      <NebulaBackground {...props} />
+      <GodRayShafts {...props} />
+      <DepthDriftParticles {...props} />
       <ParticleField seed={seed} scrollT={scrollT} />
+      {quality === "full" && <FocalBloomHalo seed={seed} scrollT={scrollT} worldIntensity={props.worldIntensity} />}
       <FocalObject seed={seed} scrollT={scrollT} />
     </Canvas>
   );

--- a/src/components/3d/WorldCanvas.tsx
+++ b/src/components/3d/WorldCanvas.tsx
@@ -832,7 +832,7 @@ function CameraRig({ seed, scrollT, pointer }: Props) {
       return;
     }
 
-    desired.current.set(pointer.x * 0.12, pointer.y * 0.08, 6 - scrollT * 0.35);
+    desired.current.set(pointer.x * 0.12, pointer.y * 0.08, 6 - scrollT * 0.35 + Math.max(0, scrollT - 0.95) * 1.4);
     target.current.set(0, -0.18, -2 - scrollT * 1.2);
     camera.position.lerp(desired.current, 0.04);
     camera.lookAt(target.current);

--- a/src/components/home/ChapterProgress.tsx
+++ b/src/components/home/ChapterProgress.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+export function ChapterProgress() {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
+
+    const marker = ref.current;
+    const section = marker?.closest<HTMLElement>(".chapter-pin");
+    if (!section) return;
+
+    let active = false;
+    let raf = 0;
+
+    const update = () => {
+      raf = 0;
+      const rect = section.getBoundingClientRect();
+      const travel = Math.max(1, rect.height - window.innerHeight);
+      const t = Math.max(0, Math.min(1, -rect.top / travel));
+      section.style.setProperty("--chapter-t", String(t));
+    };
+
+    const requestUpdate = () => {
+      if (!active || raf) return;
+      raf = requestAnimationFrame(update);
+    };
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        active = entry.isIntersecting;
+        update();
+      },
+      { rootMargin: "20% 0px" }
+    );
+
+    observer.observe(section);
+    update();
+    window.addEventListener("scroll", requestUpdate, { passive: true });
+    window.addEventListener("resize", requestUpdate);
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("scroll", requestUpdate);
+      window.removeEventListener("resize", requestUpdate);
+      if (raf) cancelAnimationFrame(raf);
+    };
+  }, []);
+
+  return <div ref={ref} className="hidden" aria-hidden="true" />;
+}

--- a/src/components/home/HeroParallax.tsx
+++ b/src/components/home/HeroParallax.tsx
@@ -12,6 +12,8 @@ import { useEffect, useRef } from "react";
  */
 export function HeroParallax() {
   const ref = useRef<HTMLDivElement>(null);
+  const lastScroll = useRef({ y: 0, time: 0 });
+  const idleTimer = useRef<number | null>(null);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -30,17 +32,40 @@ export function HeroParallax() {
       // freeze the offset so the text doesn't slide away.
       const maxOffset = rect.height * 0.5;
       const offset = Math.max(-maxOffset, Math.min(maxOffset, -rect.top * 0.6));
+      const docMax = Math.max(1, document.documentElement.scrollHeight - window.innerHeight);
+      const now = performance.now();
+      const dt = Math.max(16, now - (lastScroll.current.time || now));
+      const dy = window.scrollY - lastScroll.current.y;
+      const velocity = Math.max(-60, Math.min(60, dy / (dt / 16.67)));
+      const pageT = Math.min(1, Math.max(0, window.scrollY / docMax));
       section.style.setProperty("--scroll-px", `${offset}px`);
+      section.style.setProperty("--section-scroll-t", `${Math.max(0, Math.min(1, -rect.top / Math.max(1, rect.height)))}`);
+      document.documentElement.style.setProperty("--scroll-t", String(pageT));
+      document.documentElement.style.setProperty("--scroll-vel", String(velocity));
+      lastScroll.current = { y: window.scrollY, time: now };
+      if (idleTimer.current) window.clearTimeout(idleTimer.current);
+      idleTimer.current = window.setTimeout(() => {
+        document.documentElement.style.setProperty("--scroll-vel", "0");
+      }, 300);
     };
     const onScroll = () => {
       if (raf) return;
       raf = requestAnimationFrame(update);
     };
     window.addEventListener("scroll", onScroll, { passive: true });
+    const onPointer = (event: PointerEvent) => {
+      const x = (event.clientX / window.innerWidth) * 2 - 1;
+      const y = -((event.clientY / window.innerHeight) * 2 - 1);
+      document.documentElement.style.setProperty("--pointer-x", String(x));
+      document.documentElement.style.setProperty("--pointer-y", String(y));
+    };
+    window.addEventListener("pointermove", onPointer, { passive: true });
     update();
     return () => {
       window.removeEventListener("scroll", onScroll);
+      window.removeEventListener("pointermove", onPointer);
       if (raf) cancelAnimationFrame(raf);
+      if (idleTimer.current) window.clearTimeout(idleTimer.current);
     };
   }, []);
 

--- a/src/components/home/HeroParallax.tsx
+++ b/src/components/home/HeroParallax.tsx
@@ -12,8 +12,6 @@ import { useEffect, useRef } from "react";
  */
 export function HeroParallax() {
   const ref = useRef<HTMLDivElement>(null);
-  const lastScroll = useRef({ y: 0, time: 0 });
-  const idleTimer = useRef<number | null>(null);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -32,40 +30,18 @@ export function HeroParallax() {
       // freeze the offset so the text doesn't slide away.
       const maxOffset = rect.height * 0.5;
       const offset = Math.max(-maxOffset, Math.min(maxOffset, -rect.top * 0.6));
-      const docMax = Math.max(1, document.documentElement.scrollHeight - window.innerHeight);
-      const now = performance.now();
-      const dt = Math.max(16, now - (lastScroll.current.time || now));
-      const dy = window.scrollY - lastScroll.current.y;
-      const velocity = Math.max(-60, Math.min(60, dy / (dt / 16.67)));
-      const pageT = Math.min(1, Math.max(0, window.scrollY / docMax));
       section.style.setProperty("--scroll-px", `${offset}px`);
       section.style.setProperty("--section-scroll-t", `${Math.max(0, Math.min(1, -rect.top / Math.max(1, rect.height)))}`);
-      document.documentElement.style.setProperty("--scroll-t", String(pageT));
-      document.documentElement.style.setProperty("--scroll-vel", String(velocity));
-      lastScroll.current = { y: window.scrollY, time: now };
-      if (idleTimer.current) window.clearTimeout(idleTimer.current);
-      idleTimer.current = window.setTimeout(() => {
-        document.documentElement.style.setProperty("--scroll-vel", "0");
-      }, 300);
     };
     const onScroll = () => {
       if (raf) return;
       raf = requestAnimationFrame(update);
     };
     window.addEventListener("scroll", onScroll, { passive: true });
-    const onPointer = (event: PointerEvent) => {
-      const x = (event.clientX / window.innerWidth) * 2 - 1;
-      const y = -((event.clientY / window.innerHeight) * 2 - 1);
-      document.documentElement.style.setProperty("--pointer-x", String(x));
-      document.documentElement.style.setProperty("--pointer-y", String(y));
-    };
-    window.addEventListener("pointermove", onPointer, { passive: true });
     update();
     return () => {
       window.removeEventListener("scroll", onScroll);
-      window.removeEventListener("pointermove", onPointer);
       if (raf) cancelAnimationFrame(raf);
-      if (idleTimer.current) window.clearTimeout(idleTimer.current);
     };
   }, []);
 

--- a/src/components/home/HomeHeroActions.tsx
+++ b/src/components/home/HomeHeroActions.tsx
@@ -56,11 +56,14 @@ export function HomeStreakStatus() {
           {milestoneToast}
         </div>
       )}
-      {streakDays > 0 && (
-        <span className="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full bg-amber-500/10 border border-amber-400/20 text-amber-300 text-xs">
-          {streakEmoji || "*"} Day {streakDays}
-        </span>
-      )}
+      <span
+        aria-hidden={streakDays > 0 ? undefined : "true"}
+        className={`inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full bg-amber-500/10 border border-amber-400/20 text-amber-300 text-xs ${
+          streakDays > 0 ? "" : "invisible"
+        }`}
+      >
+        {streakDays > 0 ? `${streakEmoji || "*"} Day ${streakDays}` : "* Day 0"}
+      </span>
     </>
   );
 }

--- a/src/components/home/LiveNowTicker.tsx
+++ b/src/components/home/LiveNowTicker.tsx
@@ -21,8 +21,8 @@ interface Props {
  * phrasings are picked from a small bank — designed to feel alive without
  * being a fake number generator.
  *
- * Renders nothing on first paint (avoids hydration jitter) — the parent server
- * component still ships the H1/CTA so the page is content-complete for crawlers.
+ * Renders a deterministic first slot so the hero keeps a stable footprint
+ * before the live rotation starts after hydration.
  */
 const PHRASES = [
   "someone is opening",
@@ -35,16 +35,11 @@ const PHRASES = [
 ];
 
 export function LiveNowTicker({ items, intervalMs = 4200 }: Props) {
-  const [idx, setIdx] = useState<number | null>(null);
+  const [idx, setIdx] = useState(0);
   const [phrase, setPhrase] = useState<string>(PHRASES[0]);
 
   useEffect(() => {
     if (items.length === 0) return;
-    // Stagger the first render to feel alive without immediately overwriting
-    const firstPick = Math.floor(Math.random() * items.length);
-    setIdx(firstPick);
-    setPhrase(PHRASES[Math.floor(Math.random() * PHRASES.length)]);
-
     const id = setInterval(() => {
       setIdx((curr) => {
         const next = Math.floor(Math.random() * items.length);
@@ -57,7 +52,6 @@ export function LiveNowTicker({ items, intervalMs = 4200 }: Props) {
     return () => clearInterval(id);
   }, [items, intervalMs]);
 
-  if (idx === null) return null;
   const current = items[idx];
   if (!current) return null;
 

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -20,7 +20,7 @@ export function Footer() {
     .slice(0, 6);
 
   return (
-    <footer className="border-t border-border/40 bg-gradient-to-b from-surface/80 to-background">
+    <footer className="footer-depth-pop border-t border-border/40 bg-gradient-to-b from-surface/80 to-background">
       <div className="glow-line" />
 
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 pt-20 sm:pt-24 pb-16">

--- a/src/components/roulette/RouletteClient.tsx
+++ b/src/components/roulette/RouletteClient.tsx
@@ -269,7 +269,7 @@ export function RouletteClient({ pool }: Props) {
                       rel="noopener noreferrer"
                       data-outbound="true"
                       data-cursor="hover"
-                      className="magnetic px-5 py-2.5 rounded-xl bg-white/10 backdrop-blur-md text-white text-sm font-semibold border border-white/20 hover:bg-white/20 transition-colors"
+                      className="px-5 py-2.5 rounded-xl bg-white/10 backdrop-blur-md text-white text-sm font-semibold border border-white/20 hover:bg-white/20 transition-colors"
                     >
                       Try it ↗
                     </a>

--- a/src/components/roulette/RouletteClient.tsx
+++ b/src/components/roulette/RouletteClient.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { TiltCard3D } from "@/components/ui/TiltCard3D";
 
 interface PoolItem {
   slug: string;
@@ -93,10 +94,18 @@ export function RouletteClient({ pool }: Props) {
   const [tickerSlug, setTickerSlug] = useState<string>(pool[0]?.slug ?? "");
 
   useEffect(() => {
+    let raf = 0;
     try {
-      setHistory(JSON.parse(localStorage.getItem(HISTORY_KEY) || "[]"));
-      setFaves(JSON.parse(localStorage.getItem(FAVES_KEY) || "[]"));
+      const savedHistory = JSON.parse(localStorage.getItem(HISTORY_KEY) || "[]");
+      const savedFaves = JSON.parse(localStorage.getItem(FAVES_KEY) || "[]");
+      raf = requestAnimationFrame(() => {
+        setHistory(savedHistory);
+        setFaves(savedFaves);
+      });
     } catch {}
+    return () => {
+      if (raf) cancelAnimationFrame(raf);
+    };
   }, []);
 
   const filteredPool = useMemo(() => {
@@ -171,20 +180,19 @@ export function RouletteClient({ pool }: Props) {
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [spinning, spin, result]);
 
   return (
     <div className="space-y-12">
       {/* Mood picker */}
-      <div className="flex flex-wrap justify-center gap-2.5">
+      <div className="depth-grid flex flex-wrap justify-center gap-2.5">
         {MOODS.map((m) => (
           <button
             key={m.id}
             onClick={() => setMood(m.id)}
             data-cursor="hover"
             aria-pressed={mood === m.id}
-            className={`px-4 py-2 rounded-full text-xs uppercase tracking-[0.18em] font-semibold border transition-all ${
+            className={`magnetic px-4 py-2 rounded-full text-xs uppercase tracking-[0.18em] font-semibold border transition-all ${
               mood === m.id
                 ? "bg-white text-black border-white shadow-[0_6px_24px_rgba(255,255,255,0.25)]"
                 : "bg-white/8 text-white/85 border-white/15 hover:bg-white/15 hover:border-white/30"
@@ -200,7 +208,8 @@ export function RouletteClient({ pool }: Props) {
       </p>
 
       {/* Slot card */}
-      <div className="floating-glass relative mx-auto max-w-2xl rounded-3xl p-8 sm:p-10 overflow-hidden">
+      <TiltCard3D className="mx-auto max-w-2xl rounded-3xl" glowColor="168, 85, 247" tiltDepth="strong" maxTilt={14}>
+      <div className="floating-glass relative rounded-3xl p-8 sm:p-10 overflow-hidden">
         {/* Glow ring while spinning */}
         {spinning && (
           <div
@@ -217,7 +226,7 @@ export function RouletteClient({ pool }: Props) {
 
         <div className="relative">
           {/* Ticker / Result */}
-          <div className="min-h-[220px] flex flex-col justify-center">
+          <div className="depth-layer-2 min-h-[220px] flex flex-col justify-center">
             {!result && !spinning && (
               <p className="text-center text-white/60 italic">
                 Press <kbd className="px-1.5 py-0.5 mx-1 rounded bg-white/15 text-white text-[10px] uppercase tracking-wider">space</kbd> or hit spin to begin.
@@ -249,7 +258,7 @@ export function RouletteClient({ pool }: Props) {
                   <Link
                     href={`/item/${result.slug}`}
                     data-cursor="hover"
-                    className="px-5 py-2.5 rounded-xl bg-white text-black text-sm font-semibold hover:bg-white/90 transition-colors"
+                    className="magnetic px-5 py-2.5 rounded-xl bg-white text-black text-sm font-semibold hover:bg-white/90 transition-colors"
                   >
                     Read the take
                   </Link>
@@ -260,7 +269,7 @@ export function RouletteClient({ pool }: Props) {
                       rel="noopener noreferrer"
                       data-outbound="true"
                       data-cursor="hover"
-                      className="px-5 py-2.5 rounded-xl bg-white/10 backdrop-blur-md text-white text-sm font-semibold border border-white/20 hover:bg-white/20 transition-colors"
+                      className="magnetic px-5 py-2.5 rounded-xl bg-white/10 backdrop-blur-md text-white text-sm font-semibold border border-white/20 hover:bg-white/20 transition-colors"
                     >
                       Try it ↗
                     </a>
@@ -270,7 +279,7 @@ export function RouletteClient({ pool }: Props) {
                     data-cursor="hover"
                     aria-pressed={faves.includes(result.slug)}
                     aria-label={faves.includes(result.slug) ? "Remove from favourites" : "Save to favourites"}
-                    className={`w-10 h-10 rounded-xl flex items-center justify-center text-sm border transition-all ${
+                    className={`magnetic w-10 h-10 rounded-xl flex items-center justify-center text-sm border transition-all ${
                       faves.includes(result.slug)
                         ? "bg-amber-400 text-black border-amber-400"
                         : "bg-white/10 text-white border-white/20 hover:bg-white/20"
@@ -289,19 +298,20 @@ export function RouletteClient({ pool }: Props) {
               onClick={spin}
               data-cursor="hover"
               disabled={spinning}
-              className="px-8 py-4 rounded-2xl bg-gradient-to-r from-accent to-cyan text-white text-base font-bold uppercase tracking-[0.18em] shadow-[0_10px_40px_rgba(168,85,247,0.4)] hover:shadow-[0_14px_56px_rgba(168,85,247,0.6)] active:scale-[0.98] transition-all disabled:opacity-60 disabled:cursor-wait"
+              className="magnetic px-8 py-4 rounded-2xl bg-gradient-to-r from-accent to-cyan text-white text-base font-bold uppercase tracking-[0.18em] shadow-[0_10px_40px_rgba(168,85,247,0.4)] hover:shadow-[0_14px_56px_rgba(168,85,247,0.6)] active:scale-[0.98] transition-all disabled:opacity-60 disabled:cursor-wait"
             >
               {spinning ? "Spinning…" : result ? "Spin again" : "Spin"}
             </button>
           </div>
         </div>
       </div>
+      </TiltCard3D>
 
       {/* History */}
       {history.length > 0 && (
         <div className="text-center">
           <p className="text-xs uppercase tracking-[0.22em] text-white/55 mb-3">Recent spins</p>
-          <div className="flex flex-wrap justify-center gap-2">
+          <div className="depth-grid flex flex-wrap justify-center gap-2">
             {history.slice(0, 12).map((slug) => {
               const item = pool.find((p) => p.slug === slug);
               if (!item) return null;
@@ -310,7 +320,7 @@ export function RouletteClient({ pool }: Props) {
                   key={slug}
                   href={`/item/${slug}`}
                   data-cursor="hover"
-                  className="px-3 py-1.5 rounded-full bg-white/8 hover:bg-white/15 text-white/85 text-xs border border-white/10 hover:border-white/25 transition-all"
+                  className="magnetic px-3 py-1.5 rounded-full bg-white/8 hover:bg-white/15 text-white/85 text-xs border border-white/10 hover:border-white/25 transition-all"
                 >
                   {item.title}
                 </Link>
@@ -324,7 +334,7 @@ export function RouletteClient({ pool }: Props) {
       {faves.length > 0 && (
         <div className="text-center">
           <p className="text-xs uppercase tracking-[0.22em] text-amber-200/85 mb-3">Your favourites</p>
-          <div className="flex flex-wrap justify-center gap-2">
+          <div className="depth-grid flex flex-wrap justify-center gap-2">
             {faves.slice(0, 20).map((slug) => {
               const item = pool.find((p) => p.slug === slug);
               if (!item) return null;
@@ -333,7 +343,7 @@ export function RouletteClient({ pool }: Props) {
                   key={slug}
                   href={`/item/${slug}`}
                   data-cursor="hover"
-                  className="px-3 py-1.5 rounded-full bg-amber-400/15 hover:bg-amber-400/25 text-amber-100 text-xs border border-amber-400/30 hover:border-amber-400/50 transition-all"
+                  className="magnetic px-3 py-1.5 rounded-full bg-amber-400/15 hover:bg-amber-400/25 text-amber-100 text-xs border border-amber-400/30 hover:border-amber-400/50 transition-all"
                 >
                   ★ {item.title}
                 </Link>

--- a/src/components/roulette/RouletteClient.tsx
+++ b/src/components/roulette/RouletteClient.tsx
@@ -185,7 +185,7 @@ export function RouletteClient({ pool }: Props) {
   return (
     <div className="space-y-12">
       {/* Mood picker */}
-      <div className="depth-grid flex flex-wrap justify-center gap-2.5">
+      <div className="flex flex-wrap justify-center gap-2.5">
         {MOODS.map((m) => (
           <button
             key={m.id}
@@ -311,7 +311,7 @@ export function RouletteClient({ pool }: Props) {
       {history.length > 0 && (
         <div className="text-center">
           <p className="text-xs uppercase tracking-[0.22em] text-white/55 mb-3">Recent spins</p>
-          <div className="depth-grid flex flex-wrap justify-center gap-2">
+          <div className="flex flex-wrap justify-center gap-2">
             {history.slice(0, 12).map((slug) => {
               const item = pool.find((p) => p.slug === slug);
               if (!item) return null;
@@ -334,7 +334,7 @@ export function RouletteClient({ pool }: Props) {
       {faves.length > 0 && (
         <div className="text-center">
           <p className="text-xs uppercase tracking-[0.22em] text-amber-200/85 mb-3">Your favourites</p>
-          <div className="depth-grid flex flex-wrap justify-center gap-2">
+          <div className="flex flex-wrap justify-center gap-2">
             {faves.slice(0, 20).map((slug) => {
               const item = pool.find((p) => p.slug === slug);
               if (!item) return null;

--- a/src/components/ui/AuroraBackground.tsx
+++ b/src/components/ui/AuroraBackground.tsx
@@ -26,17 +26,17 @@ export function AuroraBackground({
     <div className={`relative overflow-hidden ${className}`}>
       {/* Blob A — slow drift top-right */}
       <div
-        className={`pointer-events-none absolute -top-32 -right-32 h-[520px] w-[520px] rounded-full ${colorA} blur-[110px]`}
+        className={`aurora-fallback-blob pointer-events-none absolute -top-32 -right-32 h-[520px] w-[520px] rounded-full ${colorA} blur-[110px]`}
         style={{ animation: "aurora-a 14s ease-in-out infinite alternate" }}
       />
       {/* Blob B — medium drift bottom-left */}
       <div
-        className={`pointer-events-none absolute -bottom-24 -left-24 h-[440px] w-[440px] rounded-full ${colorB} blur-[90px]`}
+        className={`aurora-fallback-blob pointer-events-none absolute -bottom-24 -left-24 h-[440px] w-[440px] rounded-full ${colorB} blur-[90px]`}
         style={{ animation: "aurora-b 18s ease-in-out infinite alternate" }}
       />
       {/* Blob C — fast drift center */}
       <div
-        className={`pointer-events-none absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 h-[360px] w-[360px] rounded-full ${colorC} blur-[80px]`}
+        className={`aurora-fallback-blob pointer-events-none absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 h-[360px] w-[360px] rounded-full ${colorC} blur-[80px]`}
         style={{ animation: "aurora-c 10s ease-in-out infinite alternate" }}
       />
 

--- a/src/components/ui/ScrollReveal.tsx
+++ b/src/components/ui/ScrollReveal.tsx
@@ -15,21 +15,25 @@ export function ScrollReveal({ children, delay = 0, className = "", placeholder 
   // Start visible so SSR/SSG renders content fully — JS then hides off-screen cards
   const [visible, setVisible] = useState(true);
   const [hydrated, setHydrated] = useState(false);
+  const [reducedMotion, setReducedMotion] = useState(false);
 
   useEffect(() => {
-    setHydrated(true);
+    const reduce = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches === true;
+    const hydrationRaf = requestAnimationFrame(() => {
+      setHydrated(true);
+      setReducedMotion(reduce);
+    });
     const el = ref.current;
-    if (!el) return;
+    if (!el) return () => cancelAnimationFrame(hydrationRaf);
 
     // If already in viewport on mount, keep visible (no animation needed)
     const rect = el.getBoundingClientRect();
     if (rect.top < window.innerHeight + 50) {
-      setVisible(true);
-      return;
+      return () => cancelAnimationFrame(hydrationRaf);
     }
 
     // Below viewport — hide and animate in on scroll
-    setVisible(false);
+    const visibilityRaf = requestAnimationFrame(() => setVisible(false));
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting) {
@@ -37,10 +41,14 @@ export function ScrollReveal({ children, delay = 0, className = "", placeholder 
           observer.unobserve(el);
         }
       },
-      { threshold: 0.01, rootMargin: "200px 0px 0px 0px" }
+      { threshold: 0.12, rootMargin: "120px 0px 0px 0px" }
     );
     observer.observe(el);
-    return () => observer.disconnect();
+    return () => {
+      cancelAnimationFrame(hydrationRaf);
+      cancelAnimationFrame(visibilityRaf);
+      observer.disconnect();
+    };
   }, []);
 
   /* When a placeholder is provided, show it until the card enters the viewport,
@@ -61,13 +69,15 @@ export function ScrollReveal({ children, delay = 0, className = "", placeholder 
         </div>
         {/* Real content — fades up on enter */}
         <div
-          className="absolute inset-0"
+          className={`absolute inset-0 ${reducedMotion ? "" : "reveal-3d"} ${visible ? "is-in" : ""}`}
           style={{
             opacity: visible ? 1 : 0,
-            transform: visible ? "translateY(0)" : "translateY(16px)",
             transition: hydrated
-              ? `opacity 0.6s cubic-bezier(0.16, 1, 0.3, 1) ${delay}ms, transform 0.6s cubic-bezier(0.16, 1, 0.3, 1) ${delay}ms`
+              ? reducedMotion
+                ? `opacity 0.35s ease ${delay}ms`
+                : undefined
               : "none",
+            transitionDelay: hydrated && !reducedMotion ? `${delay}ms` : undefined,
           }}
         >
           {children}
@@ -79,13 +89,15 @@ export function ScrollReveal({ children, delay = 0, className = "", placeholder 
   return (
     <div
       ref={ref}
-      className={className}
+      className={`${className} ${reducedMotion ? "" : "reveal-3d"} ${visible ? "is-in" : ""}`}
       style={{
         opacity: visible ? 1 : 0,
-        transform: visible ? "translateY(0)" : "translateY(24px)",
         transition: hydrated
-          ? `opacity 0.6s cubic-bezier(0.16, 1, 0.3, 1) ${delay}ms, transform 0.6s cubic-bezier(0.16, 1, 0.3, 1) ${delay}ms`
+          ? reducedMotion
+            ? `opacity 0.35s ease ${delay}ms`
+            : undefined
           : "none",
+        transitionDelay: hydrated && !reducedMotion ? `${delay}ms` : undefined,
       }}
     >
       {children}

--- a/src/components/ui/TiltCard.tsx
+++ b/src/components/ui/TiltCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, MouseEvent } from "react";
+import { useEffect, useRef, type PointerEvent } from "react";
 
 interface TiltCardProps {
   children: React.ReactNode;
@@ -18,35 +18,96 @@ interface TiltCardProps {
  */
 export function TiltCard({ children, className = "", maxTilt = 8, glowColor }: TiltCardProps) {
   const ref = useRef<HTMLDivElement>(null);
+  const rafRef = useRef<number | null>(null);
+  const pointerRef = useRef<{ x: number; y: number } | null>(null);
+  const cleanupExitWatchRef = useRef<(() => void) | null>(null);
 
-  function handleMouseMove(e: MouseEvent<HTMLDivElement>) {
+  useEffect(() => () => {
+    if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    cleanupExitWatchRef.current?.();
+  }, []);
+
+  function canTilt() {
+    if (typeof window === "undefined") return false;
+    if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return false;
+    if (window.matchMedia?.("(pointer: coarse)").matches) return false;
+    return true;
+  }
+
+  function resetCard() {
     const card = ref.current;
     if (!card) return;
+    if (rafRef.current) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+    pointerRef.current = null;
+    card.style.transform = "perspective(800px) rotateX(0deg) rotateY(0deg) scale3d(1,1,1)";
+    card.style.boxShadow = "";
+    cleanupExitWatchRef.current?.();
+    cleanupExitWatchRef.current = null;
+  }
+
+  function watchForExit() {
+    if (cleanupExitWatchRef.current) return;
+
+    const resetIfOutside = (event: globalThis.PointerEvent) => {
+      const card = ref.current;
+      if (!card) return;
+      const rect = card.getBoundingClientRect();
+      const outside =
+        event.clientX < rect.left ||
+        event.clientX > rect.right ||
+        event.clientY < rect.top ||
+        event.clientY > rect.bottom;
+      if (outside) resetCard();
+    };
+
+    document.addEventListener("pointermove", resetIfOutside, { passive: true });
+    window.addEventListener("scroll", resetCard, { passive: true });
+    window.addEventListener("blur", resetCard);
+
+    cleanupExitWatchRef.current = () => {
+      document.removeEventListener("pointermove", resetIfOutside);
+      window.removeEventListener("scroll", resetCard);
+      window.removeEventListener("blur", resetCard);
+    };
+  }
+
+  function applyTilt() {
+    rafRef.current = null;
+    const card = ref.current;
+    const pointer = pointerRef.current;
+    if (!card || !pointer) return;
+
     const rect = card.getBoundingClientRect();
-    const x = e.clientX - rect.left;
-    const y = e.clientY - rect.top;
+    const x = pointer.x - rect.left;
+    const y = pointer.y - rect.top;
     const cx = rect.width / 2;
     const cy = rect.height / 2;
     const rotateX = ((y - cy) / cy) * -maxTilt;
     const rotateY = ((x - cx) / cx) * maxTilt;
     card.style.transform = `perspective(800px) rotateX(${rotateX}deg) rotateY(${rotateY}deg) scale3d(1.02,1.02,1.02)`;
-    if (glowColor) {
-      card.style.boxShadow = glowColor;
-    }
+    if (glowColor) card.style.boxShadow = glowColor;
   }
 
-  function handleMouseLeave() {
-    const card = ref.current;
-    if (!card) return;
-    card.style.transform = "perspective(800px) rotateX(0deg) rotateY(0deg) scale3d(1,1,1)";
-    card.style.boxShadow = "";
+  function handlePointerMove(e: PointerEvent<HTMLDivElement>) {
+    if (!canTilt()) {
+      resetCard();
+      return;
+    }
+    pointerRef.current = { x: e.clientX, y: e.clientY };
+    watchForExit();
+    if (!rafRef.current) rafRef.current = requestAnimationFrame(applyTilt);
   }
 
   return (
     <div
       ref={ref}
-      onMouseMove={handleMouseMove}
-      onMouseLeave={handleMouseLeave}
+      onPointerMove={handlePointerMove}
+      onPointerLeave={resetCard}
+      onPointerCancel={resetCard}
+      onBlur={resetCard}
       className={`will-change-transform ${className}`}
       style={{ transition: "transform 0.15s ease-out, box-shadow 0.15s ease-out" }}
     >

--- a/src/components/ui/TiltCard3D.tsx
+++ b/src/components/ui/TiltCard3D.tsx
@@ -5,14 +5,16 @@ import { useEffect, useRef, type CSSProperties, type ReactNode } from "react";
 interface Props {
   children: ReactNode;
   className?: string;
-  /** Max tilt angle in degrees on each axis (default 12) */
+  /** Max tilt angle in degrees on each axis (default 18) */
   maxTilt?: number;
-  /** Scale on hover (default 1.025) */
+  /** Scale on hover (default 1.04) */
   hoverScale?: number;
   /** Glow color rgb string (default accent purple) */
   glowColor?: string;
+  /** Parallax strength for inner layers */
+  tiltDepth?: "strong" | "medium" | "subtle";
   /** Tag to render (default 'div') */
-  as?: "div" | "article" | "section";
+  as?: "div" | "article" | "section" | "li";
   style?: CSSProperties;
   /** Forwarded onClick for nested interactive cards */
   onClick?: () => void;
@@ -29,15 +31,17 @@ interface Props {
 export function TiltCard3D({
   children,
   className = "",
-  maxTilt = 12,
-  hoverScale = 1.025,
+  maxTilt = 18,
+  hoverScale = 1.04,
   glowColor = "168, 85, 247",
+  tiltDepth = "medium",
   as: Tag = "div",
   style,
   onClick,
 }: Props) {
   const ref = useRef<HTMLDivElement>(null);
   const animFrame = useRef<number | null>(null);
+  const lastPointer = useRef({ x: 0.5, y: 0.5, clientX: 0, clientY: 0 });
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -47,52 +51,148 @@ export function TiltCard3D({
     const el = ref.current;
     if (!el) return;
 
+    const depthLift = {
+      strong: 28,
+      medium: 20,
+      subtle: 12,
+    }[tiltDepth];
+
+    const resetMagnetic = () => {
+      el.querySelectorAll<HTMLElement>(".magnetic").forEach((target) => {
+        target.style.setProperty("--mag-x", "0px");
+        target.style.setProperty("--mag-y", "0px");
+      });
+    };
+
+    const resetNeighbors = () => {
+      const grid = el.closest<HTMLElement>(".depth-grid, [data-depth-grid='true']");
+      if (!grid) return;
+      grid.querySelectorAll<HTMLElement>(".tilt-3d").forEach((card) => {
+        card.classList.remove("is-neighbor-reacting");
+        card.style.setProperty("--neighbor-tilt-y", "0deg");
+        card.style.setProperty("--neighbor-brightness", "1");
+        card.style.setProperty("--neighbor-saturation", "1");
+      });
+      grid.style.removeProperty("--hovered-card-index");
+    };
+
+    const updateNeighbors = () => {
+      const grid = el.closest<HTMLElement>(".depth-grid, [data-depth-grid='true']");
+      if (!grid) return;
+      const cards = Array.from(grid.querySelectorAll<HTMLElement>(".tilt-3d"));
+      const hoveredIndex = cards.indexOf(el);
+      if (hoveredIndex < 0) return;
+      grid.style.setProperty("--hovered-card-index", String(hoveredIndex));
+
+      const hoveredRect = el.getBoundingClientRect();
+      const hoveredCenter = hoveredRect.left + hoveredRect.width / 2;
+      cards.forEach((card) => {
+        if (card === el) return;
+        const rect = card.getBoundingClientRect();
+        const center = rect.left + rect.width / 2;
+        const distance = Math.abs(center - hoveredCenter);
+        const strength = Math.max(0, 1 - distance / 820);
+        const direction = center < hoveredCenter ? 1 : -1;
+        card.classList.add("is-neighbor-reacting");
+        card.style.setProperty("--neighbor-tilt-y", `${direction * strength * 2.6}deg`);
+        card.style.setProperty("--neighbor-brightness", `${1 - strength * 0.15}`);
+        card.style.setProperty("--neighbor-saturation", `${1 - strength * 0.1}`);
+      });
+    };
+
     const onMove = (e: PointerEvent) => {
+      lastPointer.current.clientX = e.clientX;
+      lastPointer.current.clientY = e.clientY;
       if (animFrame.current) return;
       animFrame.current = requestAnimationFrame(() => {
         animFrame.current = null;
         const rect = el.getBoundingClientRect();
-        const x = (e.clientX - rect.left) / rect.width;  // 0..1
-        const y = (e.clientY - rect.top) / rect.height;  // 0..1
-        const tiltX = (0.5 - y) * maxTilt * 2;            // y high = tilt back
-        const tiltY = (x - 0.5) * maxTilt * 2;            // x right = tilt right
+        const x = Math.max(0, Math.min(1, (lastPointer.current.clientX - rect.left) / rect.width));
+        const y = Math.max(0, Math.min(1, (lastPointer.current.clientY - rect.top) / rect.height));
+        lastPointer.current.x = x;
+        lastPointer.current.y = y;
+        const tiltX = (0.5 - y) * maxTilt * 2;
+        const tiltY = (x - 0.5) * maxTilt * 2;
+        const rimAngle = Math.atan2(0.5 - y, x - 0.5) * (180 / Math.PI);
         el.style.setProperty("--tilt-x", `${tiltX}deg`);
         el.style.setProperty("--tilt-y", `${tiltY}deg`);
         el.style.setProperty("--mouse-x", `${x * 100}%`);
         el.style.setProperty("--mouse-y", `${y * 100}%`);
+        el.style.setProperty("--rim-angle", `${rimAngle}deg`);
         el.style.setProperty("--scale", String(hoverScale));
+        el.style.setProperty("--lift-z", `${depthLift}px`);
+
+        el.querySelectorAll<HTMLElement>(".magnetic").forEach((target) => {
+          const buttonRect = target.getBoundingClientRect();
+          const cx = buttonRect.left + buttonRect.width / 2;
+          const cy = buttonRect.top + buttonRect.height / 2;
+          const dx = lastPointer.current.clientX - cx;
+          const dy = lastPointer.current.clientY - cy;
+          const distance = Math.hypot(dx, dy);
+          if (distance > 80) {
+            target.style.setProperty("--mag-x", "0px");
+            target.style.setProperty("--mag-y", "0px");
+            return;
+          }
+          const pull = (1 - distance / 80) * 6;
+          target.style.setProperty("--mag-x", `${(dx / Math.max(distance, 1)) * pull}px`);
+          target.style.setProperty("--mag-y", `${(dy / Math.max(distance, 1)) * pull}px`);
+        });
       });
     };
 
+    const onEnter = () => {
+      el.classList.add("is-hovered");
+      updateNeighbors();
+    };
+
     const onLeave = () => {
+      el.classList.remove("is-hovered");
       el.style.setProperty("--tilt-x", "0deg");
       el.style.setProperty("--tilt-y", "0deg");
       el.style.setProperty("--scale", "1");
+      el.style.setProperty("--lift-z", "0px");
+      el.style.setProperty("--rim-angle", "0deg");
+      resetMagnetic();
+      resetNeighbors();
     };
 
+    const onCancel = () => onLeave();
+
+    el.addEventListener("pointerenter", onEnter);
     el.addEventListener("pointermove", onMove);
     el.addEventListener("pointerleave", onLeave);
+    el.addEventListener("pointercancel", onCancel);
+    window.addEventListener("blur", onLeave);
     return () => {
+      el.removeEventListener("pointerenter", onEnter);
       el.removeEventListener("pointermove", onMove);
       el.removeEventListener("pointerleave", onLeave);
+      el.removeEventListener("pointercancel", onCancel);
+      window.removeEventListener("blur", onLeave);
       if (animFrame.current) cancelAnimationFrame(animFrame.current);
+      resetMagnetic();
+      resetNeighbors();
     };
-  }, [maxTilt, hoverScale]);
+  }, [maxTilt, hoverScale, tiltDepth]);
 
   // The inner element receives the transform so child layout doesn't shift
   return (
     <Tag
       ref={ref as never}
       onClick={onClick}
-      className={`tilt-3d ${className}`}
+      data-tilt-depth={tiltDepth}
+      className={`tilt-3d specular-highlight rim-light ${className}`}
       style={
         {
           ...style,
           "--tilt-x": "0deg",
           "--tilt-y": "0deg",
           "--scale": "1",
+          "--lift-z": "0px",
           "--mouse-x": "50%",
           "--mouse-y": "50%",
+          "--rim-angle": "0deg",
           "--glow-color": glowColor,
         } as CSSProperties
       }

--- a/src/lib/world-phase.ts
+++ b/src/lib/world-phase.ts
@@ -1,0 +1,223 @@
+import type { WorldSeed } from "@/lib/world-seed";
+
+export type WorldAlcoveId =
+  | "arrival"
+  | "recognition"
+  | "heart"
+  | "inversion"
+  | "communion"
+  | "departure";
+
+export interface ItemKeyframe {
+  id: WorldAlcoveId;
+  label: string;
+  camera: [number, number, number];
+  lookAt: [number, number, number];
+  fov: number;
+  density: number;
+  objectScale: number;
+  objectY: number;
+  objectZ: number;
+  twist: number;
+  glow: number;
+}
+
+export interface ItemPhase {
+  index: number;
+  next: number;
+  t: number;
+  raw: number;
+}
+
+export interface WorldPhaseTelemetry {
+  scene: WorldSeed["scene"];
+  scrollT: number;
+  phaseIndex: number;
+  nextPhaseIndex: number;
+  mix: number;
+  raw: number;
+  id: WorldAlcoveId;
+  nextId: WorldAlcoveId;
+  label: string;
+  nextLabel: string;
+  cameraX: number;
+  cameraY: number;
+  cameraZ: number;
+  lookX: number;
+  lookY: number;
+  lookZ: number;
+  fov: number;
+  density: number;
+  objectScale: number;
+  objectY: number;
+  objectZ: number;
+  twist: number;
+  glow: number;
+}
+
+export const ITEM_KEYFRAMES: ItemKeyframe[] = [
+  {
+    id: "arrival",
+    label: "Arrival",
+    camera: [0, 0.15, 6.25],
+    lookAt: [0, -0.35, -2.1],
+    fov: 66,
+    density: 0.58,
+    objectScale: 1.0,
+    objectY: -0.42,
+    objectZ: -2.05,
+    twist: 0.22,
+    glow: 0.72,
+  },
+  {
+    id: "recognition",
+    label: "Recognition",
+    camera: [0.95, 0.55, 5.45],
+    lookAt: [0.1, -0.2, -2.7],
+    fov: 61,
+    density: 0.86,
+    objectScale: 1.18,
+    objectY: -0.18,
+    objectZ: -2.65,
+    twist: 0.58,
+    glow: 0.9,
+  },
+  {
+    id: "heart",
+    label: "Heart",
+    camera: [-1.15, 0.85, 4.75],
+    lookAt: [-0.1, -0.05, -3.25],
+    fov: 57,
+    density: 1.0,
+    objectScale: 0.92,
+    objectY: -0.02,
+    objectZ: -3.2,
+    twist: 1.08,
+    glow: 1.15,
+  },
+  {
+    id: "inversion",
+    label: "Inversion",
+    camera: [1.35, -0.05, 4.2],
+    lookAt: [0, -0.18, -3.95],
+    fov: 54,
+    density: 0.74,
+    objectScale: 1.34,
+    objectY: -0.28,
+    objectZ: -3.85,
+    twist: 0.72,
+    glow: 0.96,
+  },
+  {
+    id: "communion",
+    label: "Communion",
+    camera: [-0.55, 0.35, 3.72],
+    lookAt: [0.08, -0.32, -4.6],
+    fov: 50,
+    density: 0.96,
+    objectScale: 1.12,
+    objectY: -0.46,
+    objectZ: -4.45,
+    twist: 1.38,
+    glow: 1.22,
+  },
+  {
+    id: "departure",
+    label: "Departure",
+    camera: [0.15, 0.08, 5.15],
+    lookAt: [0, -0.55, -5.05],
+    fov: 59,
+    density: 0.64,
+    objectScale: 0.82,
+    objectY: -0.62,
+    objectZ: -5.05,
+    twist: 0.36,
+    glow: 0.66,
+  },
+];
+
+const ROUTE_PHASE_STOPS = [0, 2, 5] as const;
+
+export function clamp01(value: number): number {
+  return Math.min(1, Math.max(0, value));
+}
+
+export function smoothstep(value: number): number {
+  return value * value * (3 - 2 * value);
+}
+
+export function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+export function getItemPhase(scrollT: number): ItemPhase {
+  const scaled = clamp01(scrollT) * (ITEM_KEYFRAMES.length - 1);
+  const index = Math.min(ITEM_KEYFRAMES.length - 2, Math.floor(scaled));
+  const next = Math.min(ITEM_KEYFRAMES.length - 1, index + 1);
+  return { index, next, t: smoothstep(scaled - index), raw: scaled };
+}
+
+function getRoutePhase(scrollT: number): ItemPhase {
+  const scaled = clamp01(scrollT) * (ROUTE_PHASE_STOPS.length - 1);
+  const routeIndex = Math.min(ROUTE_PHASE_STOPS.length - 2, Math.floor(scaled));
+  const routeNext = Math.min(ROUTE_PHASE_STOPS.length - 1, routeIndex + 1);
+  return {
+    index: ROUTE_PHASE_STOPS[routeIndex],
+    next: ROUTE_PHASE_STOPS[routeNext],
+    t: smoothstep(scaled - routeIndex),
+    raw: scaled,
+  };
+}
+
+export function getWorldPhase(seed: WorldSeed, scrollT: number): ItemPhase {
+  return seed.scene === "item" ? getItemPhase(scrollT) : getRoutePhase(scrollT);
+}
+
+export function getItemSceneSnapshot(seed: WorldSeed, scrollT: number): WorldPhaseTelemetry {
+  const phase = getItemPhase(scrollT);
+  return buildTelemetry(seed, scrollT, phase);
+}
+
+export function getWorldPhaseTelemetry(seed: WorldSeed, scrollT: number): WorldPhaseTelemetry {
+  return buildTelemetry(seed, scrollT, getWorldPhase(seed, scrollT));
+}
+
+function buildTelemetry(
+  seed: WorldSeed,
+  scrollT: number,
+  phase: ItemPhase
+): WorldPhaseTelemetry {
+  const from = ITEM_KEYFRAMES[phase.index];
+  const to = ITEM_KEYFRAMES[phase.next];
+  const side = seed.rngSeed % 2 === 0 ? 1 : -1;
+  const depth = 0.9 + seed.intensity * 0.18;
+  const cameraX = lerp(from.camera[0], to.camera[0], phase.t) * side;
+  const lookX = lerp(from.lookAt[0], to.lookAt[0], phase.t) * side * 0.45;
+  const heartbeat = 0.92 + Math.sin(phase.raw * Math.PI) * 0.08;
+
+  return {
+    scene: seed.scene,
+    scrollT: clamp01(scrollT),
+    phaseIndex: phase.index,
+    nextPhaseIndex: phase.next,
+    mix: phase.t,
+    raw: phase.raw,
+    id: from.id,
+    nextId: to.id,
+    label: seed.scene === "route" && phase.index === 2 ? "Exploration" : from.label,
+    nextLabel: seed.scene === "route" && phase.next === 2 ? "Exploration" : to.label,
+    cameraX,
+    cameraY: lerp(from.camera[1], to.camera[1], phase.t),
+    cameraZ: lerp(from.camera[2], to.camera[2], phase.t) * depth,
+    lookX,
+    lookY: lerp(from.lookAt[1], to.lookAt[1], phase.t),
+    lookZ: lerp(from.lookAt[2], to.lookAt[2], phase.t),
+    fov: lerp(from.fov, to.fov, phase.t),
+    density: lerp(from.density, to.density, phase.t) * heartbeat,
+    objectScale: lerp(from.objectScale, to.objectScale, phase.t),
+    objectY: lerp(from.objectY, to.objectY, phase.t),
+    objectZ: lerp(from.objectZ, to.objectZ, phase.t),
+    twist: lerp(from.twist, to.twist, phase.t),
+    glow: lerp(from.glow, to.glow, phase.t),
+  };
+}

--- a/src/lib/world-seed.ts
+++ b/src/lib/world-seed.ts
@@ -11,6 +11,10 @@
 import { alcoveFromCategory, alcoveByKind, type Alcove } from "@/lib/alcoves";
 
 export interface WorldSeed {
+  /** Route-wide world or an item-specific reading world */
+  scene: "route" | "item";
+  /** Stable key used to derive the scene, usually pathname or slug */
+  key: string;
   /** 0..1 — hash-derived but stable per slug */
   hue: number;
   /** 0..1 — depth/intensity multiplier */
@@ -71,6 +75,8 @@ export function deriveWorldSeed(opts: {
   }
 
   return {
+    scene: opts.slug ? "item" : "route",
+    key,
     hue,
     intensity,
     density,


### PR DESCRIPTION
## Summary

Polish pass on top of the dimensional tile depth system. Fixes 14 audit items (A–N) and adds three mobile-perf extras. Mobile Lighthouse `/` 85, `/tools` 86, CLS 0.

## ⚠️ Stack order

This branch is stacked on top of two still-open PRs. **Merge order must be #95 → #96 → this PR.** Do not merge this PR before #95 and #96 land.

- #95 (codex/item-scroll-world)
- #96 (codex/scroll-locked-audio)

## Polish fixes

- **A. Strip `magnetic` from affiliate CTAs** — removed from main product CTA, outbound lead-card visit buttons, catalog visit links, roulette outbound trial link. Editorial CTAs keep `magnetic`.
- **B. Share card-grid vanishing point** — dropped inner `perspective: 1100px` from `.tilt-3d`; rows now project to the parent `.depth-grid` perspective.
- **C. Light-theme overrides** — specular highlight, rim light, hover shadow, and companion orb now read clearly on `[data-theme="light"]`.
- **D. Focus ring on tilt cards** — `.tilt-3d:focus-within` outline with reduced-motion fallback.
- **E. Move scroll-tilt off `#main-content`** — replaced with `.scroll-tilt-stage` wrapper inside sections; sections containing sticky elements skip the transform. Clamp reduced to ±1.5°.
- **F. Cursor echo threshold lowered** to 800 px/s.
- **G. Deduplicated scroll-var writers** — `GlobalWorld` is the canonical owner of `--scroll-t`, `--scroll-vel`, `--scroll-tilt`, pointer vars. `HeroParallax` keeps only hero-local `--scroll-px` / `--section-scroll-t`.
- **H. Sticky 3D chapter panels** on homepage alcoves — pinned + rotateY/translateZ driven by `--chapter-t`. Disabled on reduced-motion + coarse-pointer.
- **I. Hero zoom-out parallax** — `scale 1.18 → 1.0` on hero images via `--section-scroll-t`.
- **J. Section depth-blur on exit** — `.depth-scene` blurs up to 6px as it leaves viewport.
- **K. Page-end depth pop** — footer rise at scroll-t > 0.95 + subtle camera pullback on non-item routes.
- **L. WebGL workload trimmed** — lite-tier particle counts cut, `FocalBloomHalo` gated to `scrollT < 0.85`, R3F `performance` throttle enabled.
- **M. Scoped `.tilt-3d > *` z-index** — only explicit `.depth-layer-*` / `.tilt-3d-pop` children get lifted.
- **N. Removed `.depth-grid` from non-card rows** — roulette mood picker and other button/link rows.

## Extras (perf)

- Narrow / coarse-pointer / save-data clients stay on the CSS aurora fallback instead of booting the full WebGL world.
- Hero chips + ticker reserve first-paint space → CLS 0 on the homepage hero.
- Below-fold lead-card image preload removed so the mobile hero wins the critical path.

## Verification

- `npm run build` → 3,070 routes, 3,067 HTML files, 0 errors.
- `npm run audit:adsense` → passes.
- `npm run lint` on changed files → clean.
- Local mobile Lighthouse (gzip static): `/` 85, `/tools` 86, CLS 0. Full JSONs attached as artifacts (see commit `e76c8a0` and later).
- Browser interaction sweep at 1440×900: hover produces non-identity 3D matrix, sticky right-rail holds on item pages, focus ring visible at any tilt, footer settles at scroll end, light theme reads clearly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)